### PR TITLE
Add install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     author_email='tom@tomforb.es',
     description='Ping, but with a graph. Visit the Github page for more info',
     requires=['colorama'],
+    install_requires=['colorama'],
     entry_points={
         "console_scripts": [
             "gping=gping.pinger:run"


### PR DESCRIPTION
Pip doesn't seem to install the requirements just from `requirements` in `setup.py`. This makes it so that pip will install them when `gping` is installed.