### PR TITLE
Fix simulation mode and linux regexp.

### DIFF
--- a/gping/pinger.py
+++ b/gping/pinger.py
@@ -244,7 +244,7 @@ def run():
         url = "google.com"
 
     if url == "--sim":
-        it = _simulate()
+        it = _simulate
     else:
         it = _windows if platform.system() == "Windows" else _linux
 

--- a/gping/pinger.py
+++ b/gping/pinger.py
@@ -15,9 +15,7 @@ from gping.termsize import get_terminal_size
 init()
 windows_re = re.compile('.*?\\d+.*?\\d+.*?\\d+.*?\\d+.*?\\d+.*?(\\d+)', re.IGNORECASE | re.DOTALL)
 
-linux_re = re.compile(
-    '.*?[+-]?\\d*\\.\\d+(?![-+0-9\\.]).*?[+-]?\\d*\\.\\d+(?![-+0-9\\.]).*?([+-]?\\d*\\.\\d+)(?![-+0-9\\.])',
-    re.IGNORECASE | re.DOTALL)
+linux_re = re.compile(r'time=(\d+(?:\.\d+)?) *ms', re.IGNORECASE)
 
 buff = collections.deque([0 for _ in range(20)], maxlen=400)
 


### PR DESCRIPTION
It was not possible to start gping in simulation mode.

Your linux regexp didn't match lines containing time without the dot for example here:

    64 bytes from lhr14s23-in-f36.1e100.net (216.58.210.36): icmp_seq=2 ttl=52 time=83.6 ms
    64 bytes from lhr14s23-in-f36.1e100.net (216.58.210.36): icmp_seq=3 ttl=52 time=133 ms

It was unable to match second line (fixes #2 )

I don't know why it was so complicated too. I fixed this issue and simplified the regexp.