### PR TITLE
fix hanging on ping error

### DIFF
--- a/gping/pinger.py
+++ b/gping/pinger.py
@@ -228,6 +228,8 @@ def _windows(url):
             yield int(windows_re.search(line).group(1))
         elif "timed out" in line or "failure" in line:
             yield None
+        if ping.poll():
+            break
 
 
 def _linux(url):
@@ -236,6 +238,8 @@ def _linux(url):
         line = ping.stdout.readline().decode()
         if line.startswith("64 bytes from"):
             yield round(float(linux_re.search(line).group(1)))
+        if ping.poll():
+            break
 
 
 def _darwin(url):
@@ -246,6 +250,8 @@ def _darwin(url):
             yield round(float(darwin_re.search(line).group(5)))
         elif line.startswith("Request timeout"):
             yield None
+        if ping.poll():
+            break
 
 
 def _simulate(url):


### PR DESCRIPTION
If run with `-x` or anything not a valid URL, `ping` command (iputils) exits with an error code, but the generator is still trying to read more lines when there is none.

It (EOF) can also be checked with

    if not line:

But using `ping.poll()` is a safer option, because we want to know if there is an error, and if so, gping quits without error, although it should.

I don't have system other than Linux, so I don't know how other `ping` would respond if giving `-x`.