### PR TITLE
[Feature] Ping example.com by default instead of Google

### DIFF
--- a/gping/pinger.py
+++ b/gping/pinger.py
@@ -264,7 +264,7 @@ def _run():
     try:
         url = sys.argv[1]
     except IndexError:
-        url = "google.com"
+        url = "example.com"
 
     if url == "--sim":
         it = _simulate

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Tested on Windows and Ubuntu, should run on OS X as well. After installation jus
 
 `gping [yourhost]`
 
-If you don't give a host then it pings google.
+If you don't give a host then it pings [`example.com`](http://example.com/).
 
 ## Why?
 My apartments internet is all 4g, and while it's normally pretty fast it can be a bit flakey. I often


### PR DESCRIPTION
RFC 2606 and RFC 6761 describe how IANA reserves example.com and a few
other URLs for testing purposes.  In their own words, "These domains
may be used as illustrative examples in documents without prior
coordination with us".  Some web sites will block access based on the
amount and/or type of traffic they receive.  The example domains which
IANA reserves have no such policy.

This patch changes gping to ping `example.com` by default instead of
Google, on the grounds that it is more pragmatic---the `example.com`
domain exists specifically for tasks like this.  And more generally,
software is a better "net citizen" when it does not send unnecessary
traffic to web sites and servers.

Signed-off-by: Eric James Michael Ritz ejmr@plutono.com

See-Also: http://www.iana.org/domains/reserved
