### PR TITLE
Remove unused Bitmap.__getitem__

### DIFF
--- a/gping/pinger.py
+++ b/gping/pinger.py
@@ -50,17 +50,6 @@ class Bitmap(object):
             [default for _ in range(width + 1)]
             for _ in range(height + 1)
             ]
-    def __getitem__(self, point):
-        ''' we get the value at the given point
-            raise an error if the passed item is not Point object or Integer object
-        '''
-        if isinstance(point, P):
-            return self._bitmap[self.height - idx.y][idx.x]
-        #
-        elif not isinstance(point, int):
-            raise RuntimeError("Can only index Bitmaps using an integer")
-
-        return self._bitmap[self.height - idx]
 
     def __setitem__(self, point, value):
         ''' we set the value at the given point 


### PR DESCRIPTION
Removing unused `Bitmap.__getitem__`, which contains unresolved references to `idx`.

It appears this method once had good intentions, but the `Bitmap` abstraction is seldom used throughout the code (the `_bitmap` member is being accessed directly). It would probably be a good idea to make full use of `Bitmap`, but I'll leave that for another PR.