### PR TITLE
Small bug fixes for Darwin (MacOS)

### DIFF
--- a/gping/pinger.py
+++ b/gping/pinger.py
@@ -34,11 +34,8 @@ class Canvas(object):
     def __init__(self, width, height):
         # Each item in each row is a tuple, the first element is the single character that will be printed
         # and the second is the characters color.
-        self.data = [
-            [(" ", None) for i in range(width)]
-            for i in range(height)
-            ]
-
+        self.data = [ [(" ", None) for i in range(width)] for i in range(height - 1) ]
+        
     def __setitem__(self, key, value):
         x, y = key
 
@@ -333,6 +330,10 @@ def _run():
     else:
         it = linux_ping
 
+    width, height = get_terminal_size()
+    for i in range(height):
+        print(" ")
+
     for line in it(options):
         buff.appendleft(line)
 
@@ -342,6 +343,8 @@ def _run():
 
         if winterm and system == "Windows":
             winterm.set_cursor_position((1, 1))
+        if system == "Darwin":
+            print("\033[%sA" % height)
         else:
             print(chr(27) + "[2J")
 


### PR DESCRIPTION
Hello,

I have been using Gping for a while now and have always loved it. I do well with visualizations and this creates a really good visualization of a network connection with very little overhead. Which I like :)

However, I have always noticed that on my computers (all macs) the graphs would print one after another and create huge amounts of text in my terminal window. I finally bit the bullet and decided to dive in and figure out how to fix it.

I have pushed a very minimal changeset, outlined below:

- Populate initial Canvas object with one fewer line. When the canvas lines were joined there was an extra newline being printed which over time generates a huge amount of blank space in the terminal.  
- Added code to generate a blank “graph” prior to the first graph being drawn. This allows for the Darwin cursor to move back to the initial spot. I am concerned with portability to Windows and Linux and don’t have a box to test on.  
- Added if clause to move cursor to the start of the area where the graph should be graphed. The linux terminal escape was not moving the cursor on Darwin which resulted in the graphs being printed to the terminal subsequently which quickly filled up a terminal with graphs.

I would feel much better if someone tested these changes on a Windows box. I unfortunately don't have access to one right now. I did test on both Darwin (MacOS Sierra) and Linux (Ubuntu 16.04) and gping runs as expected on both :)

I would love any feedback you have :) 

Thanks!
\- Kyle


