### PR TITLE
Fix snapcraft badge link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# gping ![Snap Status](https://build.snapcraft.io/badge/orf/gping.svg) ![](https://img.shields.io/pypi/v/pinggraph.svg) ![]( 	https://img.shields.io/pypi/pyversions/pinggraph.svg) ![](https://img.shields.io/pypi/format/pinggraph.svg)
+# gping [![Snap Status](https://build.snapcraft.io/badge/orf/gping.svg)](https://build.snapcraft.io/user/orf/gping) ![](https://img.shields.io/pypi/v/pinggraph.svg) ![]( 	https://img.shields.io/pypi/pyversions/pinggraph.svg) ![](https://img.shields.io/pypi/format/pinggraph.svg)
 Ping, but with a graph
 
 ![](/doc/readme_screencast.gif)


### PR DESCRIPTION
Thanks for making gping. I've fixed up the link to the snapcraft build page from the badge.