### PR TITLE
Fix the crash when the window is resized too small

### DIFF
--- a/gping/pinger.py
+++ b/gping/pinger.py
@@ -37,7 +37,7 @@ class Canvas(object):
         # Each item in each row is a tuple, the first element is the single character that will be printed
         # and the second is the characters color.
         self.data = [ [(" ", None) for i in range(width)] for i in range(height - 1) ]
-        
+
     def __setitem__(self, key, value):
         x, y = key
 
@@ -158,7 +158,7 @@ def plot(width, height, data, host):
             # If it's a timeout then do a red questionmark
             canvas[column + 2, 2] = ("?", Fore.RED)
             continue
-        
+
         # Only draw a bar if the max_ping has been more than 0
         if max_ping > 0:
            # What percentage of the max_ping are we? 0 -> 1
@@ -183,10 +183,10 @@ def plot(width, height, data, host):
         )
 
     stats_box = [
-        "Avg: {:6.0f}".format(average_ping),
-        "Min: {:6.0f}".format(min(filtered_data)),  # Filter None values
+        "Cur: {:6.0f}".format(filtered_data[0]),
         "Max: {:6.0f}".format(max(filtered_data)),
-        "Cur: {:6.0f}".format(filtered_data[0])
+        "Min: {:6.0f}".format(min(filtered_data)),  # Filter None values
+        "Avg: {:6.0f}".format(average_ping)
     ]
     # creating the box for the ping information in the middle
     midpoint = Point(
@@ -196,16 +196,18 @@ def plot(width, height, data, host):
     max_stats_len = max(len(s) for s in stats_box)
     # Draw a box around the outside of the stats box. We do this to stop the bars from touching the text,
     # it looks weird. We need a blank area around it.
+    stats_text = min(height - 2, midpoint.y + len(stats_box) / 2)
     canvas.box(
-        Point(midpoint.x - round(max_stats_len / 2) - 1, midpoint.y + len(stats_box)),
-        Point(midpoint.x + round(max_stats_len / 2) - 1, midpoint.y - 1),
+        Point(midpoint.x - round(max_stats_len / 2) - 1, stats_text + 1),
+        Point(midpoint.x + round(max_stats_len / 2) - 1, stats_text - len(stats_box)),
         blank=True
     )
     # Paint each of the statistics lines
     for idx, stat in enumerate(stats_box):
         from_stat = midpoint.x - round(max_stats_len / 2)
         to_stat = from_stat + len(stat)
-        canvas.horizontal_line(stat, midpoint.y + idx, from_stat, to_stat)
+        if stats_text - idx >= 0:
+            canvas.horizontal_line(stat, stats_text - idx, from_stat, to_stat)
 
     # adding the url to the top
     if host:


### PR DESCRIPTION
Fixes #48. This patch draw the statistics from top to bottom and ensure nothing is drawn outside the window (tested with a minimum of 20x5).