### PR TITLE
Use ringbuffer instead of using memcpy to shift element at EVERY PUSH

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod ringbuffer;
+
 use anyhow::Result;
 use crossterm::event::{KeyEvent, KeyModifiers};
 use crossterm::{
@@ -36,7 +38,7 @@ struct Args {
 }
 
 struct App {
-    data: Vec<(f64, f64)>,
+    data: ringbuffer::FixedRingBuffer<(f64, f64)>,
     capacity: usize,
     idx: i64,
     window: [f64; 2],
@@ -45,7 +47,7 @@ struct App {
 impl App {
     fn new(capacity: usize) -> Self {
         App {
-            data: Vec::with_capacity(capacity),
+            data: ringbuffer::FixedRingBuffer::new(capacity),
             capacity,
             idx: 0,
             window: [0.0, capacity as f64],
@@ -54,7 +56,6 @@ impl App {
     fn update(&mut self, item: Option<Duration>) {
         self.idx += 1;
         if self.data.len() >= self.capacity {
-            self.data.remove(0);
             self.window[0] += 1_f64;
             self.window[1] += 1_f64;
         }
@@ -205,7 +206,7 @@ fn main() -> Result<()> {
                         .marker(symbols::Marker::Braille)
                         .style(Style::default().fg(Color::Cyan))
                         .graph_type(GraphType::Line)
-                        .data(&app.data);
+                        .data(&app.data.as_slice());
 
                     let y_axis_bounds = app.y_axis_bounds();
 

--- a/src/ringbuffer.rs
+++ b/src/ringbuffer.rs
@@ -1,0 +1,71 @@
+use std::fmt::Debug;
+
+#[derive(Debug)]
+pub struct FixedRingBuffer<T> {
+    buf: Vec<T>,
+    cap: usize,
+    head: usize,
+}
+
+impl<T: Copy + Default> FixedRingBuffer<T> {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            buf: Vec::with_capacity(2 * capacity),
+            cap: capacity,
+            head: 0,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.buf.len() - self.head
+    }
+
+    pub fn push(&mut self, elem: T) {
+        // shift left if buffer is full, use pointer to memmove
+        // already reduced memory allocation with larger buffer
+        if self.buf.len() == self.buf.capacity() {
+            let len = self.buf.len();
+            self.buf.copy_within(self.head + 1..len, 0);
+            self.buf.resize(self.cap - 1, Default::default());
+            self.head = 0;
+        }
+        self.buf.push(elem);
+        if self.buf.len() > self.cap {
+            self.head += 1;
+        }
+    }
+
+    pub fn as_slice(&self) -> &[T] {
+        &self.buf[self.head..self.buf.len()]
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<T> {
+        self.as_slice().iter()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::FixedRingBuffer;
+
+    #[test]
+    pub fn test_basic_push() {
+        let mut ringbuffer = FixedRingBuffer::new(3);
+        let expect = vec![
+            vec![0],
+            vec![0, 1],
+            vec![0, 1, 2],
+            vec![1, 2, 3],
+            vec![2, 3, 4],
+            vec![3, 4, 5],
+            vec![4, 5, 6],
+            vec![5, 6, 7],
+            vec![6, 7, 8],
+            vec![7, 8, 9],
+        ];
+        for (x, expect) in (0..10).zip(expect.iter()) {
+            ringbuffer.push(x);
+            assert_eq!(ringbuffer.as_slice(), expect.as_slice());
+        }
+    }
+}


### PR DESCRIPTION
This introduces a data structure that replaces `Vec<(f64, f64)>` so that it does not perform a shift left at every push when its at full capacity. This should introduce performance benefits when the buffer is large enough. Additionally, this data structure performs better the larger the buffer size.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>