### PR TITLE
Allow users to specify custom buffer sizes.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,9 +29,10 @@ struct Args {
     #[structopt(
         short,
         long,
-        help = "Determines the number pings to display. Defaults to 100"
+        default_value = "100",
+        help = "Determines the number pings to display."
     )]
-    buffer: Option<usize>,
+    buffer: usize,
 }
 
 struct App {
@@ -116,7 +117,7 @@ enum Event {
 
 fn main() -> Result<()> {
     let args = Args::from_args();
-    let mut app = App::new(args.buffer.unwrap_or(100));
+    let mut app = App::new(args.buffer);
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,12 @@ use tui::{symbols, Terminal};
 struct Args {
     #[structopt(help = "Host or IP to ping")]
     host: String,
+    #[structopt(
+        short,
+        long,
+        help = "Determines the number pings to display. Defaults to 100"
+    )]
+    buffer: Option<usize>,
 }
 
 struct App {
@@ -110,8 +116,7 @@ enum Event {
 
 fn main() -> Result<()> {
     let args = Args::from_args();
-
-    let mut app = App::new(100);
+    let mut app = App::new(args.buffer.unwrap_or(100));
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;


### PR DESCRIPTION
Allows the user to specify a number for the amount of pings to store and display. Defaults to the original 100.
Might wanna add some kinda dumping mechanism in the future.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>