### PR TITLE
Simplify homebrew installtion command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,8 +23,7 @@ Table of Contents
 ## Homebrew (MacOS + Linux)
 
 ```bash
-brew tap orf/brew
-brew install gping
+brew install orf/brew/gping
 ```
 
 ## Binaries (Windows)


### PR DESCRIPTION
This will automatically run `brew tap orf/brew`, and is more convenient.