### PR TITLE
MVP: Ability to specify a file to write to.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -209,7 +209,7 @@ fn main() -> Result<()> {
         let key_tx = tx.clone();
         let key_thread = thread::spawn(move || -> Result<()> {
             while !killed_signal.load(Ordering::Acquire) {
-                if event::poll(Duration::from_secs(1))? {
+                if event::poll(Duration::from_secs(0))? {
                     if let CEvent::Key(key) = event::read()? {
                         key_tx.send(Event::Input(key))?;
                     }
@@ -277,66 +277,68 @@ fn main() -> Result<()> {
                                 .as_ref(),
                         )
                         .split(f.size());
-                    let host_iterations = host_iterations.lock().unwrap();
-                    for (((host_id, host), stats), &style) in args
-                        .hosts
-                        .iter()
-                        .enumerate()
-                        .zip(app.stats())
-                        .zip(&app.styles)
                     {
-                        let header_layout = Layout::default()
-                            .direction(Direction::Horizontal)
-                            .constraints(
-                                [
-                                    Constraint::Percentage(20),
-                                    Constraint::Percentage(20),
-                                    Constraint::Percentage(20),
-                                    Constraint::Percentage(20),
-                                    Constraint::Percentage(20),
-                                ]
-                                .as_ref(),
-                            )
-                            .split(chunks[host_id]);
+                        let host_iterations = host_iterations.lock().unwrap();
+                        for (((host_id, host), stats), &style) in args
+                            .hosts
+                            .iter()
+                            .enumerate()
+                            .zip(app.stats())
+                            .zip(&app.styles)
+                        {
+                            let header_layout = Layout::default()
+                                .direction(Direction::Horizontal)
+                                .constraints(
+                                    [
+                                        Constraint::Percentage(20),
+                                        Constraint::Percentage(20),
+                                        Constraint::Percentage(20),
+                                        Constraint::Percentage(20),
+                                        Constraint::Percentage(20),
+                                    ]
+                                    .as_ref(),
+                                )
+                                .split(chunks[host_id]);
 
-                        f.render_widget(
-                            Paragraph::new(format!("Pinging {}", host)).style(style),
-                            header_layout[0],
-                        );
+                            f.render_widget(
+                                Paragraph::new(format!("Pinging {}", host)).style(style),
+                                header_layout[0],
+                            );
 
-                        f.render_widget(
-                            Paragraph::new(format!(
-                                "min {:?}",
-                                Duration::from_micros(stats.minimum().unwrap_or(0))
-                            ))
-                            .style(style),
-                            header_layout[1],
-                        );
-                        f.render_widget(
-                            Paragraph::new(format!(
-                                "max {:?}",
-                                Duration::from_micros(stats.maximum().unwrap_or(0))
-                            ))
-                            .style(style),
-                            header_layout[2],
-                        );
-                        f.render_widget(
-                            Paragraph::new(format!(
-                                "p95 {:?}",
-                                Duration::from_micros(stats.percentile(95.0).unwrap_or(0))
-                            ))
-                            .style(style),
-                            header_layout[3],
-                        );
+                            f.render_widget(
+                                Paragraph::new(format!(
+                                    "min {:?}",
+                                    Duration::from_micros(stats.minimum().unwrap_or(0))
+                                ))
+                                .style(style),
+                                header_layout[1],
+                            );
+                            f.render_widget(
+                                Paragraph::new(format!(
+                                    "max {:?}",
+                                    Duration::from_micros(stats.maximum().unwrap_or(0))
+                                ))
+                                .style(style),
+                                header_layout[2],
+                            );
+                            f.render_widget(
+                                Paragraph::new(format!(
+                                    "p95 {:?}",
+                                    Duration::from_micros(stats.percentile(95.0).unwrap_or(0))
+                                ))
+                                .style(style),
+                                header_layout[3],
+                            );
 
-                        f.render_widget(
-                            Paragraph::new(format!(
-                                "iteration {:?}",
-                                host_iterations.get(&host_id).unwrap_or(&0)
-                            ))
-                            .style(style),
-                            header_layout[4],
-                        );
+                            f.render_widget(
+                                Paragraph::new(format!(
+                                    "iteration {:?}",
+                                    host_iterations.get(&host_id).unwrap_or(&0)
+                                ))
+                                .style(style),
+                                header_layout[4],
+                            );
+                        }
                     }
 
                     let datasets: Vec<_> = app

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,7 +257,6 @@ fn main() -> Result<()> {
         threads.push(writer_thread);
     }
 
-    let host_iterations = std::sync::Arc::clone(&host_iterations);
     loop {
         match rx.recv()? {
             Event::Update(host_id, ping_result) => {
@@ -278,7 +277,6 @@ fn main() -> Result<()> {
                         )
                         .split(f.size());
                     {
-                        let host_iterations = host_iterations.lock().unwrap();
                         for (((host_id, host), stats), &style) in args
                             .hosts
                             .iter()
@@ -290,11 +288,10 @@ fn main() -> Result<()> {
                                 .direction(Direction::Horizontal)
                                 .constraints(
                                     [
-                                        Constraint::Percentage(20),
-                                        Constraint::Percentage(20),
-                                        Constraint::Percentage(20),
-                                        Constraint::Percentage(20),
-                                        Constraint::Percentage(20),
+                                        Constraint::Percentage(25),
+                                        Constraint::Percentage(25),
+                                        Constraint::Percentage(25),
+                                        Constraint::Percentage(25),
                                     ]
                                     .as_ref(),
                                 )
@@ -328,15 +325,6 @@ fn main() -> Result<()> {
                                 ))
                                 .style(style),
                                 header_layout[3],
-                            );
-
-                            f.render_widget(
-                                Paragraph::new(format!(
-                                    "iteration {:?}",
-                                    host_iterations.get(&host_id).unwrap_or(&0)
-                                ))
-                                .style(style),
-                                header_layout[4],
                             );
                         }
                     }


### PR DESCRIPTION
This PR comes with a lot of code changes. It is becoming quite unwieldy, maybe consider a refactoring? Like I think the key parsing thing is perfect, I don't want to keep seeing it.

TODO:

1. Clear out the writer buffer before we exit.
2. I think `HashMap` is better than `Vec` here because we keep trying to access this from different threads. But I am just guessing here.
3. Unify the backing buffer used by writer and grapher so we don't use twice as much memory.
4. Maybe figure out a way to not use so many mutexes and so many allocations to write stuff.