### PR TITLE
Fix: Handle unknown host (#104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ version = "0.1.8-alpha.0"
 dependencies = [
  "anyhow",
  "crossterm",
+ "dns-lookup",
  "histogram",
  "pinger",
  "structopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ tui = { version = "0.12.0", features = ["crossterm"], default_features = false }
 crossterm = "0.17.7"
 anyhow = "1.0.34"
 histogram = "0.6.9"
+dns-lookup = "1.0.5"
 
 [profile.release]
 lto = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,12 +7,16 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
+use dns_lookup::lookup_host;
 use histogram::Histogram;
 use pinger::{ping, PingResult};
+use std::collections::HashMap;
 use std::io;
 use std::io::Write;
 use std::iter;
+use std::net::IpAddr;
 use std::ops::Add;
+use std::process;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc;
 use std::thread;
@@ -46,6 +50,7 @@ struct App {
     idx: Vec<i64>,
     window_min: Vec<f64>,
     window_max: Vec<f64>,
+    map_host_ip: HashMap<String, String>,
 }
 
 impl App {
@@ -61,6 +66,7 @@ impl App {
             idx: vec![0; host_count],
             window_min: vec![0.0; host_count],
             window_max: vec![capacity as f64; host_count],
+            map_host_ip: HashMap::new(),
         }
     }
     fn update(&mut self, host_id: usize, item: Option<Duration>) {
@@ -122,6 +128,19 @@ impl App {
             .map(|i| Span::raw(format!("{:?}", duration.add(increment * i))))
             .collect()
     }
+    fn get_hosts_ipaddr(&mut self, hosts: &Vec<String>) {
+        for (_host_id, host) in hosts.iter().cloned().enumerate() {
+            let ipaddr: Vec<IpAddr> = match lookup_host(&host) {
+                Ok(ip) => ip,
+                Err(_) => {
+                    println!("Cannot resolve '{}': Unknown host", &host);
+                    process::exit(1);
+                }
+            };
+            let _ipaddr = ipaddr.first();
+            self.map_host_ip.insert(host, _ipaddr.unwrap().to_string());
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -133,6 +152,7 @@ enum Event {
 fn main() -> Result<()> {
     let args = Args::from_args();
     let mut app = App::new(args.hosts.len(), args.buffer);
+    app.get_hosts_ipaddr(&args.hosts);
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
@@ -149,12 +169,17 @@ fn main() -> Result<()> {
     let killed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
     for (host_id, host) in args.hosts.iter().cloned().enumerate() {
+        let real_host = match app.map_host_ip.get(&host) {
+            Some(ip) => &ip,
+            _ => &host,
+        }
+        .to_owned();
         let ping_tx = key_tx.clone();
 
         let killed_ping = std::sync::Arc::clone(&killed);
         // Pump ping messages into the queue
         let ping_thread = thread::spawn(move || -> Result<()> {
-            let stream = ping(host)?;
+            let stream = ping(real_host)?;
             while !killed_ping.load(Ordering::Acquire) {
                 ping_tx.send(Event::Update(host_id, stream.recv()?))?;
             }


### PR DESCRIPTION
This PR fixes the reported issue #104 , gping unknown hosts get a "receiving on a closed channel" error and need to reset terminal after press CTRL+C. It will resolve the dns before proceed and exit if host is unknown.

```
$ gping www.asdfasdgfasdg.com
Cannot resolve 'www.asdfasdgfasdg.com': Unknown host
```