### PR TITLE
Adding flags to force host resolution to IPv4 or IPv6

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Table of Contents
 * Windows/ARM: Download the latest release from [the github releases page](https://github.com/orf/gping/releases)
 * Fedora ([COPR](https://copr.fedorainfracloud.org/coprs/atim/gping/)): `sudo dnf copr enable atim/gping -y && sudo dnf install gping`
 * Cargo (**This requires `rustc` version 1.44.0 or greater**): `cargo install gping`
-* Ubuntu/Debian ([Azlux's repo](http://packages.azlux.fr/)): 
+* Ubuntu/Debian ([Azlux's repo](http://packages.azlux.fr/)):
 ```bash
 echo "deb http://packages.azlux.fr/debian/ buster main" | sudo tee /etc/apt/sources.list.d/azlux.list
 wget -qO - https://azlux.fr/repo.gpg.key | sudo apt-key add -
@@ -34,7 +34,7 @@ Just run `gping [host]`.
 
 ```bash
 $ gping --help
-gping 0.1.8
+gping 1.0.2
 Ping, but with a graph.
 
 USAGE:
@@ -43,6 +43,8 @@ USAGE:
 FLAGS:
         --cmd        Graph the execution time for a list of commands rather than pinging hosts
     -h, --help       Prints help information
+    -4               Resolve ping targets to IPv4 address
+    -6               Resolve ping targets to IPv6 address
     -V, --version    Prints version information
 
 OPTIONS:

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,12 @@ struct Args {
         help = "Determines the number pings to display."
     )]
     buffer: usize,
+    /// Resolve ping targets to IPv4 address
+    #[structopt(short = "4", conflicts_with = "ipv6")]
+    ipv4: bool,
+    /// Resolve ping targets to IPv6 address
+    #[structopt(short = "6", conflicts_with = "ipv4")]
+    ipv6: bool,
 }
 
 struct App {
@@ -195,13 +201,29 @@ fn start_ping_thread(
     })
 }
 
-fn get_host_ipaddr(host: &str) -> Result<String> {
+fn get_host_ipaddr(host: &str, force_ipv4: bool, force_ipv6: bool) -> Result<String> {
     let ipaddr: Vec<IpAddr> = match lookup_host(host) {
         Ok(ip) => ip,
         Err(_) => return Err(anyhow!("Could not resolve hostname {}", host)),
     };
-    let ipaddr = ipaddr.first();
-    Ok(ipaddr.unwrap().to_string())
+    let ipaddr = if force_ipv4 {
+        ipaddr
+            .iter()
+            .filter(|ip| matches!(ip, IpAddr::V4(_)))
+            .next()
+            .ok_or_else(|| anyhow!("Could not resolve '{}' to IPv4", host))
+    } else if force_ipv6 {
+        ipaddr
+            .iter()
+            .filter(|ip| matches!(ip, IpAddr::V6(_)))
+            .next()
+            .ok_or_else(|| anyhow!("Could not resolve '{}' to IPv6", host))
+    } else {
+        ipaddr
+            .first()
+            .ok_or_else(|| anyhow!("Could not resolve '{}' to IP", host))
+    };
+    Ok(ipaddr?.to_string())
 }
 
 fn main() -> Result<()> {
@@ -212,7 +234,11 @@ fn main() -> Result<()> {
     for (idx, host_or_cmd) in args.hosts_or_commands.iter().enumerate() {
         let display = match args.cmd {
             true => host_or_cmd.to_string(),
-            false => format!("{} ({})", host_or_cmd, get_host_ipaddr(host_or_cmd)?),
+            false => format!(
+                "{} ({})",
+                host_or_cmd,
+                get_host_ipaddr(host_or_cmd, args.ipv4, args.ipv6)?
+            ),
         };
         data.push(PlotData::new(
             display,


### PR DESCRIPTION
Adding a flag to force IPv4/IPv6:

```
$ cargo run -- icanhazip.com
icanhazip.com (2604:1380:45f1:3c00::1)
...
```


```
$ cargo run -- icanhazip.com -6
icanhazip.com (2604:1380:45f1:3c00::1)
...
```

```
$ cargo run -- icanhazip.com -4
 icanhazip.com (147.75.47.199)
...
```

If an A or AAAA record isn't found:
```
$ cargo run -- github.com -6
Error: Could not resolve 'github.com' to IPv6
```