### PR TITLE
Fix chart label to better align with results min/max values

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -105,10 +105,12 @@ impl App {
         let max = bounds[1];
 
         let difference = max - min;
-        let increment = Duration::from_micros((difference / 3f64) as u64);
+        let num_labels = 7;
+        // Split difference into one chunk for each of the 7 labels
+        let increment = Duration::from_micros((difference / num_labels as f64) as u64);
         let duration = Duration::from_micros(min as u64);
 
-        (0..7)
+        (0..num_labels)
             .map(|i| Span::raw(format!("{:?}", duration.add(increment * i))))
             .collect()
     }


### PR DESCRIPTION
The issue brought up in #115 is a result of the generated labels having too large of an increment and accumulating well past the maximum value. 

This PR calculates labels more true to the min/max values by chunking the max - min difference into the same 7 chunks that are used for the labels. There's still a chance for misalignment on either sides, but this is much closer.

![Screen Shot 2020-12-02 at 10 03 45 AM](https://user-images.githubusercontent.com/5152011/100912763-c0826d80-3485-11eb-8026-d44fb2a9f7c1.png)

![Screen Shot 2020-12-02 at 10 03 59 AM](https://user-images.githubusercontent.com/5152011/100912776-c710e500-3485-11eb-8fd5-b333f9194cf1.png)
