### PR TITLE
docs: add Arch Linux installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,13 @@ wget -qO - https://azlux.fr/repo.gpg.key | sudo apt-key add -
 apt update
 apt install gping
 ```
+* Arch Linux ([AUR](https://aur.archlinux.org/packages/?O=0&SeB=nd&K=Ping%2C+but+with+a+graph&outdated=&SB=n&SO=a&PP=50&do_Search=Go)):
+```bash
+git clone https://aur.archlinux.org/gping.git
+cd gping
+makepkg -si
+# or use an AUR helper (e.g. `paru gping`)
+```
 
 # Usage :saxophone:
 


### PR DESCRIPTION
Hey,
I'm an [Arch Linux](https://aur.archlinux.org) package [maintainer](https://github.com/orhun/PKGBUILDs). I'm submitting this PR to let you know that I created the following package for the installation of `gping` on Arch Linux:

* [gping](https://aur.archlinux.org/packages/gping/) (builds from source)

I also updated readme.md about installation from AUR. (c679bf3)

Regards,
orhun.