### PR TITLE
Added flag to use simpler dot-based graphics

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,11 +45,12 @@ USAGE:
     gping [FLAGS] [OPTIONS] [hosts-or-commands]...
 
 FLAGS:
-        --cmd        Graph the execution time for a list of commands rather than pinging hosts
-    -h, --help       Prints help information
-    -4               Resolve ping targets to IPv4 address
-    -6               Resolve ping targets to IPv6 address
-    -V, --version    Prints version information
+        --cmd                Graph the execution time for a list of commands rather than pinging hosts
+    -h, --help               Prints help information
+    -4                       Resolve ping targets to IPv4 address
+    -6                       Resolve ping targets to IPv6 address
+    -s, --simple-graphics    Uses dot characters instead of braille
+    -V, --version            Prints version information
 
 OPTIONS:
     -b, --buffer <buffer>                    Determines the number of seconds to display in the graph. [default: 30]

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,8 @@ struct Args {
     /// Resolve ping targets to IPv6 address
     #[structopt(short = "6", conflicts_with = "ipv4")]
     ipv6: bool,
+    #[structopt(short = "s", long, help = "Uses dot characters instead of braille")]
+    simple_graphics: bool,
 }
 
 struct App {
@@ -269,6 +271,7 @@ fn main() -> Result<()> {
             display,
             args.buffer,
             Style::default().fg(Color::Indexed(idx as u8 + 1)),
+            args.simple_graphics,
         ));
     }
 

--- a/src/plot_data.rs
+++ b/src/plot_data.rs
@@ -12,15 +12,17 @@ pub struct PlotData {
     pub data: Vec<(f64, f64)>,
     pub style: Style,
     buffer: chrono::Duration,
+    simple_graphics: bool,
 }
 
 impl PlotData {
-    pub fn new(display: String, buffer: u64, style: Style) -> PlotData {
+    pub fn new(display: String, buffer: u64, style: Style, simple_graphics: bool) -> PlotData {
         PlotData {
             display,
             data: Vec::with_capacity(150), // ringbuffer::FixedRingBuffer::new(capacity),
             style,
             buffer: chrono::Duration::seconds(buffer as i64),
+            simple_graphics,
         }
     }
     pub fn update(&mut self, item: Option<Duration>) {
@@ -78,7 +80,11 @@ impl<'a> Into<Dataset<'a>> for &'a PlotData {
     fn into(self) -> Dataset<'a> {
         let slice = self.data.as_slice();
         Dataset::default()
-            .marker(symbols::Marker::Braille)
+            .marker(if self.simple_graphics {
+                symbols::Marker::Dot
+            } else {
+                symbols::Marker::Braille
+            })
             .style(self.style)
             .graph_type(GraphType::Line)
             .data(slice)


### PR DESCRIPTION
Added the --simple-graphics/-s flag to use dot characters instead of braille for compatibility.

This is basically the same as how it's done in the tui-rs demos (https://github.com/fdehau/tui-rs/blob/master/examples/crossterm_demo.rs) but inverted to make the default more clear.

Solves #122