### PR TITLE
(fix) display timeouts correctly see #127

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -357,10 +357,11 @@ fn main() -> Result<()> {
                             .direction(Direction::Horizontal)
                             .constraints(
                                 [
-                                    Constraint::Percentage(25),
-                                    Constraint::Percentage(25),
-                                    Constraint::Percentage(25),
-                                    Constraint::Percentage(25),
+                                    Constraint::Percentage(20),
+                                    Constraint::Percentage(20),
+                                    Constraint::Percentage(20),
+                                    Constraint::Percentage(20),
+                                    Constraint::Percentage(20),
                                 ]
                                 .as_ref(),
                             )

--- a/src/plot_data.rs
+++ b/src/plot_data.rs
@@ -54,7 +54,7 @@ impl PlotData {
         let items: Vec<&f64> = self
             .data
             .iter()
-            .filter(|(_,x)| ! x.is_nan())
+            .filter(|(_, x)| !x.is_nan())
             .sorted_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
             .map(|(_, v)| v)
             .collect();
@@ -66,8 +66,7 @@ impl PlotData {
         let p95 = items.get(rounded_position).map(|i| **i).unwrap_or(0f64);
 
         // count timeouts
-        let to = self.data.iter().filter(|(_,x)| x.is_nan()).count();
-
+        let to = self.data.iter().filter(|(_, x)| x.is_nan()).count();
 
         vec![
             ping_header,
@@ -77,8 +76,7 @@ impl PlotData {
                 .style(self.style),
             Paragraph::new(format!("p95 {:?}", Duration::from_micros(p95 as u64)))
                 .style(self.style),
-            Paragraph::new(format!("timeout# {:?}", to))
-                .style(self.style),
+            Paragraph::new(format!("timeout# {:?}", to)).style(self.style),
         ]
     }
 }

--- a/src/plot_data.rs
+++ b/src/plot_data.rs
@@ -48,9 +48,6 @@ impl PlotData {
 
     pub fn header_stats(&self) -> Vec<Paragraph> {
         let ping_header = Paragraph::new(self.display.clone()).style(self.style);
-        if self.data.is_empty() {
-            return vec![ping_header];
-        }
         let items: Vec<&f64> = self
             .data
             .iter()
@@ -58,6 +55,10 @@ impl PlotData {
             .sorted_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
             .map(|(_, v)| v)
             .collect();
+        if items.is_empty() {
+            return vec![ping_header];
+        }
+
         let min = **items.first().unwrap();
         let max = **items.last().unwrap();
 


### PR DESCRIPTION
I fixed the issue #127.
Now timeouts get displayed correctly (no new values in graph and min value).
I also added a field where the number of timeouts are counted.
I would be happy if my fix gets integrated.