### PR TITLE
Add MacPorts Documentation + Repology

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,9 +13,15 @@ Table of Contents
    * [Install :cd:](#install-cd)
    * [Usage :saxophone:](#usage-saxophone)
 
+<a href="https://repology.org/project/gping/versions">
+    <img src="https://repology.org/badge/vertical-allrepos/gping.svg" alt="Packaging status" align="right">
+</a>
+
 # Install :cd:
 
-* Homebrew: `brew install gping`
+* macOS
+  * [Homebrew](https://formulae.brew.sh/formula/gping#default): `brew install gping`
+  * [MacPorts](https://ports.macports.org/port/gping/): `sudo port install gping`
 * Linux (Homebrew): `brew install orf/brew/gping`
 * CentOS (and other distributions with an old glibc): Download the MUSL build from the latest release
 * Windows/ARM: 


### PR DESCRIPTION
Since v0.1.7, gping has been available on [MacPorts](https://ports.macports.org/). Inspired by https://github.com/orf/gping/pull/141, I thought I'd document this.

You can find the project page [here](https://ports.macports.org/port/gping/), and it can be installed by running the following on macOS:

```
sudo port install gping
```

Pre-built binaries are available all the way from macOS 11 arm to Mavericks. I also added the [repology](https://repology.org/) badge and Homebrew page for this project.

Finally, it goes without saying, but thanks @orf for maintaining this really useful tool. Your updates and bugfixes are greatly appreciated.