### PR TITLE
Add NixOS as supported type

### DIFF
--- a/pinger/src/lib.rs
+++ b/pinger/src/lib.rs
@@ -153,6 +153,7 @@ pub fn ping_with_interval(addr: String, interval: Duration) -> Result<mpsc::Rece
         | Type::EndeavourOS
         | Type::Fedora
         | Type::Linux
+        | Type::NixOS
         | Type::Manjaro
         | Type::Mint
         | Type::openSUSE


### PR DESCRIPTION
Support was broken for NixOS - and it was needed to add `os_info::Type::NixOS` to a match-clause in `pinger::ping_with_interval(..)`