### PR TITLE
Add customisable vertical and horizontal margins

### DIFF
--- a/gping/src/main.rs
+++ b/gping/src/main.rs
@@ -80,9 +80,17 @@ struct Args {
     ipv6: bool,
     #[structopt(short = "s", long, help = "Uses dot characters instead of braille")]
     simple_graphics: bool,
-    #[structopt(long, help = "Vertical margin around the graph (top and bottom)", default_value = "1")]
+    #[structopt(
+        long,
+        help = "Vertical margin around the graph (top and bottom)",
+        default_value = "1"
+    )]
     vertical_margin: u16,
-    #[structopt(long, help = "Horizontal margin around the graph (left and right)", default_value = "0")]
+    #[structopt(
+        long,
+        help = "Horizontal margin around the graph (left and right)",
+        default_value = "0"
+    )]
     horizontal_margin: u16,
 }
 

--- a/gping/src/main.rs
+++ b/gping/src/main.rs
@@ -80,6 +80,10 @@ struct Args {
     ipv6: bool,
     #[structopt(short = "s", long, help = "Uses dot characters instead of braille")]
     simple_graphics: bool,
+    #[structopt(long, help = "Vertical margin around the graph (top and bottom)", default_value = "1")]
+    vertical_margin: u16,
+    #[structopt(long, help = "Horizontal margin around the graph (left and right)", default_value = "0")]
+    horizontal_margin: u16,
 }
 
 struct App {
@@ -358,7 +362,8 @@ fn main() -> Result<()> {
                     // Split our
                     let chunks = Layout::default()
                         .direction(Direction::Vertical)
-                        .margin(1)
+                        .vertical_margin(args.vertical_margin)
+                        .horizontal_margin(args.horizontal_margin)
                         .constraints(
                             iter::repeat(Constraint::Length(1))
                                 .take(app.data.len())


### PR DESCRIPTION
When `gping` used in tight spaces (e.g. in a small pane of `tmux`) then having that default `1` as vertical margin could be quite a waste of screen estate.   This PR adds support to override both the vertical and horizontal margins, whilst keeping it backward compatible, i.e. the vertical defaults to `1` and the horizontal defaults to `0`.