### PR TITLE
Add support for custom colors to be defined by either name or code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "dns-lookup",
  "itertools",
  "pinger",
+ "read_color",
  "shadow-rs",
  "structopt",
  "tui",
@@ -495,6 +496,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "read_color"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f4c8858baa4ad3c8bcc156ae91a0ffe22b76a3975c40c49b4f04c15c6bce0da"
 
 [[package]]
 name = "redox_syscall"

--- a/gping/Cargo.toml
+++ b/gping/Cargo.toml
@@ -20,6 +20,7 @@ chrono = "0.4.19"
 itertools = "0.10.1"
 shadow-rs = "0.8"
 const_format = "0.2.22"
+read_color = "1.0.0"
 
 [build-dependencies]
 shadow-rs = "0.8"

--- a/gping/src/colors.rs
+++ b/gping/src/colors.rs
@@ -1,0 +1,84 @@
+use std::{iter::Iterator, ops::RangeFrom};
+
+use anyhow::{anyhow, Result};
+use read_color::rgb;
+use tui::style::Color;
+
+pub struct Colors<T> {
+    already_used: Vec<Color>,
+    color_names: T,
+    indices: RangeFrom<u8>,
+}
+
+impl<T> From<T> for Colors<T> {
+    fn from(color_names: T) -> Self {
+        Self {
+            already_used: Vec::new(),
+            color_names,
+            indices: 2..,
+        }
+    }
+}
+
+impl<'a, T> Iterator for Colors<T>
+where
+    T: Iterator<Item = &'a String>,
+{
+    type Item = Result<Color>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.color_names.next() {
+            Some(name) => match try_color_from_string(name) {
+                Ok(color) => {
+                    if !self.already_used.contains(&color) {
+                        self.already_used.push(color);
+                    }
+                    Some(Ok(color))
+                }
+                error => Some(error),
+            },
+            None => loop {
+                let index = unsafe { self.indices.next().unwrap_unchecked() };
+                let color = Color::Indexed(index);
+                if !self.already_used.contains(&color) {
+                    self.already_used.push(color);
+                    break Some(Ok(color));
+                }
+            },
+        }
+    }
+}
+
+fn try_color_from_string(string: &String) -> Result<Color> {
+    let mut characters = string.chars();
+
+    let color = if let Some('#') = characters.next() {
+        match rgb(&mut characters) {
+            Some([r, g, b]) => Color::Rgb(r, g, b),
+            None => return Err(anyhow!("Invalid color code: `{}`", string)),
+        }
+    } else {
+        use Color::*;
+        match string.to_lowercase().as_str() {
+            "black" => Black,
+            "red" => Red,
+            "green" => Green,
+            "yellow" => Yellow,
+            "blue" => Blue,
+            "magenta" => Magenta,
+            "cyan" => Cyan,
+            "gray" => Gray,
+            "dark-gray" => DarkGray,
+            "light-red" => LightRed,
+            "light-green" => LightGreen,
+            "light-yellow" => LightYellow,
+            "light-blue" => LightBlue,
+            "light-magenta" => LightMagenta,
+            "light-cyan" => LightCyan,
+            "white" => White,
+            invalid => return Err(anyhow!("Invalid color name: `{}`", invalid)),
+        }
+    };
+
+    Ok(color)
+}


### PR DESCRIPTION
This PR implements customisable colour support for `gping` via the `-c` / `--color` flag.

If no value is defined then `gping` behaves as it did before.

If any number of flags are defined then their values are matched against the _hosts or commands_ arguments.  If less colours have been specified than _hosts or commands_ it enumerates the colour values by index (as before).

Colours can be defined by names (the ones which are supported by `tui`) or by hexadecimal RGB codes.  

This feature is also trying to be clever about the already used colours, however `tui::style::Color`s are not represented the same way so this _smart_ feature likely ends up being _dumb_ when it comes to detect colours which have not already being specified by the user.  (The user is allowed to define duplicates, that's by design.)