### PR TITLE
Fix rendering readme for crates.io

### DIFF
--- a/gping/README.md
+++ b/gping/README.md
@@ -1,0 +1,1 @@
+../readme.md


### PR DESCRIPTION
I noticed that [gping crate page](https://crates.io/crates/gping) wasn't showing the readme. I looked at the serde source tree and they handle it like this so should work here too in theory.