### PR TITLE
clear graph from terminal history

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,4 +93,6 @@ Options:
           Print help information
   -V, --version
           Print version information
+      --clear
+          Clear the graph from the terminal after closing the program
 ```


### PR DESCRIPTION
This change clears the GUI from your terminal history, assuming that you don't want to view the graph after you close it. Here's an example of the new and old behaviour. 

![Peek 2023-05-22 12-23](https://github.com/orf/gping/assets/39339036/f1261952-8695-4a47-8176-62cb9a350e19)


Also fixed a small clippy lint. 