### PR TITLE
clean-up(color.rs): remove `try_color_from_string`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,6 @@ dependencies = [
  "itertools",
  "pinger",
  "ratatui",
- "read_color",
  "shadow-rs",
 ]
 
@@ -627,12 +626,6 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
 ]
-
-[[package]]
-name = "read_color"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4c8858baa4ad3c8bcc156ae91a0ffe22b76a3975c40c49b4f04c15c6bce0da"
 
 [[package]]
 name = "redox_syscall"

--- a/gping/Cargo.toml
+++ b/gping/Cargo.toml
@@ -11,16 +11,15 @@ readme = "../readme.md"
 
 [dependencies]
 pinger = { version = "^0.12.1", path = "../pinger" }
-tui = { package = "ratatui", version = "0.22.0", features = ["crossterm"], default_features = false }
+tui = { package = "ratatui", version = "0.21.0", features = ["crossterm"], default_features = false }
 crossterm = "0.26.1"
-anyhow = "1.0.72"
+anyhow = "1.0.69"
 dns-lookup = "2.0.0"
 chrono = "0.4.26"
 itertools = "0.11.0"
 shadow-rs = "0.23.0"
 const_format = "0.2.31"
-read_color = "1.0.0"
-clap = { version = "4.3.19", features = ["derive"] }
+clap = { version = "4.3.11", features = ["derive"] }
 
 [build-dependencies]
 shadow-rs = "0.23.0"

--- a/gping/Cargo.toml
+++ b/gping/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../readme.md"
 
 [dependencies]
 pinger = { version = "^0.12.1", path = "../pinger" }
-tui = { package = "ratatui", version = "0.21.0", features = ["crossterm"], default_features = false }
+tui = { package = "ratatui", version = "0.22.0", features = ["crossterm"], default_features = false }
 crossterm = "0.26.1"
 anyhow = "1.0.69"
 dns-lookup = "2.0.0"

--- a/gping/src/colors.rs
+++ b/gping/src/colors.rs
@@ -34,6 +34,8 @@ where
             // Note: Revisit this section when Ratatui supports patterns such
             // as "light-red". At that point, this replacement operation
             // will be unnecessary and can be removed.
+            //
+            // See https://github.com/tui-rs-revival/ratatui/issues/305
             Some(name) => match Color::from_str(&name.replace('-', " ")) {
                 Ok(color) => {
                     if !self.already_used.contains(&color) {

--- a/gping/src/colors.rs
+++ b/gping/src/colors.rs
@@ -1,7 +1,6 @@
-use std::{iter::Iterator, ops::RangeFrom};
+use std::{iter::Iterator, ops::RangeFrom, str::FromStr};
 
 use anyhow::{anyhow, Result};
-use read_color::rgb;
 use tui::style::Color;
 
 pub struct Colors<T> {
@@ -28,14 +27,23 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.color_names.next() {
-            Some(name) => match try_color_from_string(name) {
+            // TODO: As of v0.21.0, Ratatui only accepts color patterns
+            // formatted as "lightred" or "light red". We replace any '-' in
+            // the color name with a space for compatibility.
+            //
+            // Note: Revisit this section when Ratatui supports patterns such
+            // as "light-red". At that point, this replacement operation
+            // will be unnecessary and can be removed.
+            Some(name) => match Color::from_str(&name.replace('-', " ")) {
                 Ok(color) => {
                     if !self.already_used.contains(&color) {
                         self.already_used.push(color);
                     }
                     Some(Ok(color))
                 }
-                error => Some(error),
+                error => Some(error.map_err(|err| {
+                    anyhow!(err).context(format!("Invalid color code: `{}`", name))
+                })),
             },
             None => loop {
                 let index = unsafe { self.indices.next().unwrap_unchecked() };
@@ -47,38 +55,4 @@ where
             },
         }
     }
-}
-
-fn try_color_from_string(string: &str) -> Result<Color> {
-    let mut characters = string.chars();
-
-    let color = if let Some('#') = characters.next() {
-        match rgb(&mut characters) {
-            Some([r, g, b]) => Color::Rgb(r, g, b),
-            None => return Err(anyhow!("Invalid color code: `{}`", string)),
-        }
-    } else {
-        use Color::*;
-        match string.to_lowercase().as_str() {
-            "black" => Black,
-            "red" => Red,
-            "green" => Green,
-            "yellow" => Yellow,
-            "blue" => Blue,
-            "magenta" => Magenta,
-            "cyan" => Cyan,
-            "gray" => Gray,
-            "dark-gray" => DarkGray,
-            "light-red" => LightRed,
-            "light-green" => LightGreen,
-            "light-yellow" => LightYellow,
-            "light-blue" => LightBlue,
-            "light-magenta" => LightMagenta,
-            "light-cyan" => LightCyan,
-            "white" => White,
-            invalid => return Err(anyhow!("Invalid color name: `{}`", invalid)),
-        }
-    };
-
-    Ok(color)
 }

--- a/gping/src/main.rs
+++ b/gping/src/main.rs
@@ -105,15 +105,16 @@ struct Args {
         long = "color",
         use_value_delimiter = true,
         value_delimiter = ',',
-        help = "\
-            Assign color to a graph entry. This option can be defined more than \
-            once as a comma separated string, and the order which the colors are \
-            provided will be matched against the hosts or commands passed to gping. \
-            Hexadecimal RGB color codes are accepted in the form of '#RRGGBB' or the \
-            following color names: 'black', 'red', 'green', 'yellow', 'blue', 'magenta',\
-            'cyan', 'gray', 'dark-gray', 'light-red', 'light-green', 'light-yellow', \
-            'light-blue', 'light-magenta', 'light-cyan', and 'white'\
-        "
+        help = r#"Assign color to a graph entry. 
+
+This option can be defined more than once as a comma separated string, and the 
+order which the colors are provided will be matched against the hosts or 
+commands passed to gping.
+
+Hexadecimal RGB color codes are accepted in the form of '#RRGGBB' or the 
+following color names: 'black', 'red', 'green', 'yellow', 'blue', 'magenta',
+'cyan', 'gray', 'dark-gray', 'light-red', 'light-green', 'light-yellow', 
+'light-blue', 'light-magenta', 'light-cyan', and 'white'"#
     )]
     color_codes_or_names: Vec<String>,
     #[arg(


### PR DESCRIPTION
Fixes https://github.com/orf/gping/issues/331

Removes `try_color_from_string` since this has been implemented in the Ratatui style mod.

Left one TODO for future possible changes to the naming convention.

Update the long help text of the color option.