### PR TITLE
fixed reference typing issue

### DIFF
--- a/gping/src/main.rs
+++ b/gping/src/main.rs
@@ -487,8 +487,7 @@ fn main() -> Result<()> {
                             iter::repeat(Constraint::Length(1))
                                 .take(app.data.len())
                                 .chain(iter::once(Constraint::Percentage(10)))
-                                .collect::<Vec<_>>()
-                                .as_ref(),
+                                .collect::<Vec<_>>(),
                         )
                         .split(f.size());
 


### PR DESCRIPTION
fixes #394

the .as_ref() call was breaking the typing somewhere, removing it seems to have fixed the issue. i am not familiar enough with the codebase to know if the actual issue is that &Vec<Constraint> should implement Into<Constraint>, but this seems to work