### PR TITLE
Better docker examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,10 @@ sudo emerge net-misc/gping::dm9pZCAq
   * [ports](https://cgit.freebsd.org/ports/tree/net-mgmt/gping) `cd /usr/ports/net-mgmt/gping; make install clean`
 * Docker:
 ```sh
-docker run ghcr.io/orf/gping:gping-v1.14.0 -- --help
+# Check all options
+docker run --rm -ti --network host ghcr.io/orf/gping:gping-v1.15.1 --help
+# Ping google.com
+docker run --rm -ti --network host ghcr.io/orf/gping:gping-v1.15.1 google.com
 ```
 
 # Usage :saxophone:


### PR DESCRIPTION
- Adding `--rm` so no container is kept after the end of execution (on `docker ps -a`)
- Adding `-ti` so `q` works to exit
- Adding `--network host` so uses the same network as the host
- Bumped version to 1.15.1