### PR TITLE
Add an option to display the whole history of times in the graph

### DIFF
--- a/gping.1
+++ b/gping.1
@@ -52,8 +52,9 @@ Default for ping is 0.2,
 default for cmd is 0.5.
 .TP
 \f[B]-b\f[R], \f[B]--buffer\f[R] <BUFFER>
-Determines the number of seconds to display in the graph.
-[default: 30]
+Determines the number of seconds to display in the graph. Pass 0 for
+an indefinitely scaling buffer that displays the entire history.
+[default: 0]
 .TP
 \f[B]-4\f[R]
 Resolve ping targets to IPv4 address

--- a/gping/src/main.rs
+++ b/gping/src/main.rs
@@ -73,8 +73,8 @@ struct Args {
     #[arg(
         short,
         long,
-        default_value = "30",
-        help = "Determines the number of seconds to display in the graph."
+        default_value = "0",
+        help = "Determines the number of seconds to display in the graph. Pass 0 for an indefinitely scaling buffer that displays the entire history."
     )]
     buffer: u64,
     /// Resolve ping targets to IPv4 address
@@ -176,7 +176,10 @@ impl App {
         let now = Local::now();
         let now_idx;
         let before_idx;
-        if (now - self.started) < self.display_interval {
+        if self.display_interval.is_zero() {
+            now_idx = now.timestamp_millis() as f64 / 1_000f64;
+            before_idx = self.started.timestamp_millis() as f64 / 1_000f64;
+        } else if (now - self.started) < self.display_interval {
             now_idx = (self.started + self.display_interval).timestamp_millis() as f64 / 1_000f64;
             before_idx = self.started.timestamp_millis() as f64 / 1_000f64;
         } else {

--- a/gping/src/plot_data.rs
+++ b/gping/src/plot_data.rs
@@ -33,16 +33,18 @@ impl PlotData {
             None => self.data.push((idx, f64::NAN)),
         }
         // Find the last index that we should remove.
-        let earliest_timestamp = (now - self.buffer).timestamp_millis() as f64 / 1_000f64;
-        let last_idx = self
-            .data
-            .iter()
-            .enumerate()
-            .filter(|(_, (timestamp, _))| *timestamp < earliest_timestamp)
-            .map(|(idx, _)| idx)
-            .last();
-        if let Some(idx) = last_idx {
-            self.data.drain(0..idx).for_each(drop)
+        if !self.buffer.is_zero() {
+            let earliest_timestamp = (now - self.buffer).timestamp_millis() as f64 / 1_000f64;
+            let last_idx = self
+                .data
+                .iter()
+                .enumerate()
+                .filter(|(_, (timestamp, _))| *timestamp < earliest_timestamp)
+                .map(|(idx, _)| idx)
+                .last();
+            if let Some(idx) = last_idx {
+                self.data.drain(0..idx).for_each(drop)
+            }
         }
     }
 


### PR DESCRIPTION
Now passing `--buffer 0` will scale the graph's x axis so that the entire history is always visible.

I made this option the new default, because I expect most users want a graphical ping plotter when they're dealing with network connection issues, and want to start figuring out why — this is why I came across `gping` at least. Keeping the entire history in frame lets you see at a glance whether the issues appear to be periodic or not.

