### PR TITLE
Specify `Flex::Legacy` for `Layout`. #460

### DIFF
--- a/gping/src/main.rs
+++ b/gping/src/main.rs
@@ -25,7 +25,7 @@ use std::thread;
 use std::thread::{sleep, JoinHandle};
 use std::time::{Duration, Instant};
 use tui::backend::{Backend, CrosstermBackend};
-use tui::layout::{Constraint, Direction, Layout};
+use tui::layout::{Constraint, Direction, Layout, Flex};
 use tui::style::{Color, Style};
 use tui::text::Span;
 use tui::widgets::{Axis, Block, Borders, Chart, Dataset};
@@ -480,6 +480,7 @@ fn main() -> Result<()> {
             Event::Render => {
                 terminal.draw(|f| {
                     let chunks = Layout::default()
+                        .flex(Flex::Legacy)
                         .direction(Direction::Vertical)
                         .vertical_margin(args.vertical_margin)
                         .horizontal_margin(args.horizontal_margin)


### PR DESCRIPTION
`ratatui` `0.26.0` has a breaking change that affects this crate:

https://github.com/ratatui-org/ratatui/blob/60bd7f48140023483a5281365dc4561011050dae/BREAKING-CHANGES.md?plain=1#L23

This PR specifies `Flow::Legacy` to the `chunks` `Layout` to avoid the behaviour mentioned in #460 that is a result of this.