### PR TITLE
tcp ping feature

### DIFF
--- a/gping.1
+++ b/gping.1
@@ -4,7 +4,7 @@
 .SH NAME
 gping \- Ping, but with a graph.
 .SH SYNOPSIS
-\fBgping\fR [\fB\-\-cmd\fR] [\fB\-n\fR|\fB\-\-watch\-interval\fR] [\fB\-b\fR|\fB\-\-buffer\fR] [\fB\-4 \fR] [\fB\-6 \fR] [\fB\-i\fR|\fB\-\-interface\fR] [\fB\-s\fR|\fB\-\-simple\-graphics\fR] [\fB\-\-vertical\-margin\fR] [\fB\-\-horizontal\-margin\fR] [\fB\-\-ymin\fR] [\fB\-\-ymax\fR] [\fB\-0 \fR] [\fB\-c\fR|\fB\-\-color\fR] [\fB\-\-clear\fR] [\fB\-\-ping\-args\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIHOSTS_OR_COMMANDS\fR] 
+\fBgping\fR [\fB\-\-cmd\fR] [\fB\-n\fR|\fB\-\-watch\-interval\fR] [\fB\-b\fR|\fB\-\-buffer\fR] [\fB\-4 \fR] [\fB\-6 \fR] [\fB\-i\fR|\fB\-\-interface\fR] [\fB\-s\fR|\fB\-\-simple\-graphics\fR] [\fB\-\-vertical\-margin\fR] [\fB\-\-horizontal\-margin\fR] [\fB\-\-ymin\fR] [\fB\-\-ymax\fR] [\fB\-0 \fR] [\fB\-\-tcp\fR] [\fB\-\-tcp\-rst\fR] [\fB\-\-tcp\-port\fR] [\fB\-c\fR|\fB\-\-color\fR] [\fB\-\-clear\fR] [\fB\-\-ping\-args\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIHOSTS_OR_COMMANDS\fR] 
 .SH DESCRIPTION
 Ping, but with a graph.
 .SH OPTIONS
@@ -44,6 +44,15 @@ Set vertical axis max (ms)
 .TP
 \fB\-0\fR
 Equivalent to \-\-ymin=0
+.TP
+\fB\-\-tcp\fR
+Use TCP pings instead of ICMP
+.TP
+\fB\-\-tcp\-rst\fR
+Count a connection refused (RST) as a successful ping: the host answered, it just isn\*(Aqt listening on the port
+.TP
+\fB\-\-tcp\-port\fR \fI<TCP_PORT>\fR [default: 80]
+Port to connect to (only used for TCP pings)
 .TP
 \fB\-c\fR, \fB\-\-color\fR \fI<color>\fR
 Assign color to a graph entry.

--- a/gping.1
+++ b/gping.1
@@ -48,8 +48,18 @@ Equivalent to \-\-ymin=0
 \fB\-\-tcp\fR
 Use TCP pings instead of ICMP
 .TP
-\fB\-\-tcp\-rst\fR
-Count a connection refused (RST) as a successful ping: the host answered, it just isn\*(Aqt listening on the port
+\fB\-\-tcp\-rst\fR \fI<TCP_RST>\fR [default: pong]
+How to treat a connection refused (RST) when TCP pinging
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+pong: Count it as a successful ping: the host answered, it just isn\*(Aqt listening
+.IP \(bu 2
+drop: Count it as a failed ping
+.RE
 .TP
 \fB\-\-tcp\-port\fR \fI<TCP_PORT>\fR [default: 80]
 Port to connect to (only used for TCP pings)
@@ -73,7 +83,7 @@ Clear the graph from the terminal after closing the program
 Extra arguments to pass to `ping`. These are platform dependent
 .TP
 \fB\-h\fR, \fB\-\-help\fR
-Print help
+Print help (see a summary with \*(Aq\-h\*(Aq)
 .TP
 [\fIHOSTS_OR_COMMANDS\fR]
 Hosts or IPs to ping, or commands to run if \-\-cmd is provided. Can use cloud shorthands like aws:eu\-west\-1

--- a/gping/src/main.rs
+++ b/gping/src/main.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use chrono::prelude::*;
 use clap::{CommandFactory, Parser};
 use itertools::{Itertools, MinMaxResult};
-use pinger::{ping, PingOptions, PingResult};
+use pinger::{ping, PingMode, PingOptions, PingResult};
 use std::io;
 use std::io::BufWriter;
 use std::iter;
@@ -98,16 +98,17 @@ struct Args {
     ymin_zero: bool,
 
     /// Use TCP pings instead of ICMP
-    #[arg(long, short = 't', default_value_t = false)]
-    tcping: bool,
+    #[arg(long, default_value_t = false)]
+    tcp: bool,
 
-    /// Treat RST as a drop (default is to not consider RST as pong)
-    #[arg(long, short = 'r', default_value_t = false)]
-    no_rst: bool,
+    /// Count a connection refused (RST) as a successful ping: the host answered, it
+    /// just isn't listening on the port.
+    #[arg(long, default_value_t = false, requires = "tcp")]
+    tcp_rst: bool,
 
-    /// TCP port (only used for TCP pings)
-    #[arg(long, short = 'p', default_value_t = 80)]
-    port: u16,
+    /// Port to connect to (only used for TCP pings)
+    #[arg(long, default_value_t = 80, requires = "tcp")]
+    tcp_port: u16,
 
     #[arg(
         name = "color",
@@ -489,11 +490,11 @@ fn main() -> Result<()> {
             if let Some(ping_args) = &ping_args {
                 ping_opts = ping_opts.with_raw_arguments(ping_args.clone());
             }
-            if args.tcping {
-                ping_opts = ping_opts
-                    .with_tcping(true)
-                    .with_port(args.port)
-                    .with_allow_rst(args.no_rst);
+            if args.tcp {
+                ping_opts = ping_opts.with_mode(PingMode::TCP {
+                    allow_rst: args.tcp_rst,
+                    port: Some(args.tcp_port),
+                });
             }
             threads.push(start_ping_thread(
                 ping_opts,

--- a/gping/src/main.rs
+++ b/gping/src/main.rs
@@ -101,10 +101,9 @@ struct Args {
     #[arg(long, default_value_t = false)]
     tcp: bool,
 
-    /// Count a connection refused (RST) as a successful ping: the host answered, it
-    /// just isn't listening on the port.
-    #[arg(long, default_value_t = false, requires = "tcp")]
-    tcp_rst: bool,
+    /// How to treat a connection refused (RST) when TCP pinging
+    #[arg(long, value_enum, default_value_t = RstBehaviour::Pong, requires = "tcp")]
+    tcp_rst: RstBehaviour,
 
     /// Port to connect to (only used for TCP pings)
     #[arg(long, default_value_t = 80, requires = "tcp")]
@@ -137,6 +136,25 @@ following color names: 'black', 'red', 'green', 'yellow', 'blue', 'magenta',
     /// Extra arguments to pass to `ping`. These are platform dependent.
     #[arg(long, allow_hyphen_values = true, num_args = 0.., conflicts_with="cmd")]
     ping_args: Option<Vec<String>>,
+}
+
+/// Mirrors [`pinger::RstBehaviour`] so the choice can be parsed by clap without the
+/// pinger crate having to depend on it.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+enum RstBehaviour {
+    /// Count it as a successful ping: the host answered, it just isn't listening
+    Pong,
+    /// Count it as a failed ping
+    Drop,
+}
+
+impl From<RstBehaviour> for pinger::RstBehaviour {
+    fn from(value: RstBehaviour) -> Self {
+        match value {
+            RstBehaviour::Pong => pinger::RstBehaviour::Pong,
+            RstBehaviour::Drop => pinger::RstBehaviour::Drop,
+        }
+    }
 }
 
 struct App {
@@ -492,7 +510,7 @@ fn main() -> Result<()> {
             }
             if args.tcp {
                 ping_opts = ping_opts.with_mode(PingMode::TCP {
-                    allow_rst: args.tcp_rst,
+                    rst: args.tcp_rst.into(),
                     port: Some(args.tcp_port),
                 });
             }

--- a/gping/src/main.rs
+++ b/gping/src/main.rs
@@ -490,10 +490,10 @@ fn main() -> Result<()> {
                 ping_opts = ping_opts.with_raw_arguments(ping_args.clone());
             }
             if args.tcping {
-              ping_opts = ping_opts
-                  .with_tcping(true)
-                  .with_port(args.port)
-                  .with_allow_rst(args.no_rst);
+                ping_opts = ping_opts
+                    .with_tcping(true)
+                    .with_port(args.port)
+                    .with_allow_rst(args.no_rst);
             }
             threads.push(start_ping_thread(
                 ping_opts,

--- a/gping/src/main.rs
+++ b/gping/src/main.rs
@@ -97,6 +97,18 @@ struct Args {
     #[arg(short = '0', help = "Equivalent to --ymin=0", conflicts_with = "ymin")]
     ymin_zero: bool,
 
+    /// Use TCP pings instead of ICMP
+    #[arg(long, short = 't', default_value_t = false)]
+    tcping: bool,
+
+    /// Treat RST as a drop (default is to not consider RST as pong)
+    #[arg(long, short = 'r', default_value_t = false)]
+    no_rst: bool,
+
+    /// TCP port (only used for TCP pings)
+    #[arg(long, short = 'p', default_value_t = 80)]
+    port: u16,
+
     #[arg(
         name = "color",
         short = 'c',
@@ -473,10 +485,16 @@ fn main() -> Result<()> {
             } else {
                 PingOptions::new(host_or_cmd, interval, interface.clone())
             };
+
             if let Some(ping_args) = &ping_args {
                 ping_opts = ping_opts.with_raw_arguments(ping_args.clone());
             }
-
+            if args.tcping {
+              ping_opts = ping_opts
+                  .with_tcping(true)
+                  .with_port(args.port)
+                  .with_allow_rst(args.no_rst);
+            }
             threads.push(start_ping_thread(
                 ping_opts,
                 host_id,

--- a/pinger/examples/tcp_ping.rs
+++ b/pinger/examples/tcp_ping.rs
@@ -1,0 +1,42 @@
+
+use pinger::{ping, PingOptions};
+use std::env;
+use std::time::Duration;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: tcp_ping <host> [port]");
+        return;
+    }
+
+    let host = &args[1];
+    let port: u16 = if args.len() >= 3 {
+        args[2].parse().expect("Port must be a number")
+    } else {
+        80 // default port
+    };
+
+    let opts = PingOptions::new(host, Duration::from_secs(1), None)
+        .with_tcping(true)  // enable TCP ping
+        .with_port(port)    // set port
+        .with_allow_rst(false); // treat RST as pong
+
+    let rx = ping(opts).expect("Failed to start TCP ping");
+
+    for result in rx {
+        match result {
+            pinger::PingResult::Pong(dur, target) => {
+                println!("PONG {} in {:?}", target, dur);
+            }
+            pinger::PingResult::Timeout(target) => {
+                println!("TIMEOUT {}", target);
+            }
+            pinger::PingResult::Unknown(target) => {
+                println!("UNKNOWN {}", target);
+            }
+            pinger::PingResult::PingExited(_, _) => {}
+        }
+    }
+}
+

--- a/pinger/examples/tcp_ping.rs
+++ b/pinger/examples/tcp_ping.rs
@@ -1,4 +1,4 @@
-use pinger::{ping, PingMode, PingOptions};
+use pinger::{ping, PingMode, PingOptions, RstBehaviour};
 use std::env;
 use std::time::Duration;
 
@@ -17,7 +17,7 @@ fn main() {
     };
 
     let opts = PingOptions::new(host, Duration::from_secs(1), None).with_mode(PingMode::TCP {
-        allow_rst: false, // treat RST as a timeout rather than a pong
+        rst: RstBehaviour::Pong,
         port: Some(port),
     });
 

--- a/pinger/examples/tcp_ping.rs
+++ b/pinger/examples/tcp_ping.rs
@@ -1,4 +1,3 @@
-
 use pinger::{ping, PingOptions};
 use std::env;
 use std::time::Duration;
@@ -18,8 +17,8 @@ fn main() {
     };
 
     let opts = PingOptions::new(host, Duration::from_secs(1), None)
-        .with_tcping(true)  // enable TCP ping
-        .with_port(port)    // set port
+        .with_tcping(true) // enable TCP ping
+        .with_port(port) // set port
         .with_allow_rst(false); // treat RST as pong
 
     let rx = ping(opts).expect("Failed to start TCP ping");
@@ -39,4 +38,3 @@ fn main() {
         }
     }
 }
-

--- a/pinger/examples/tcp_ping.rs
+++ b/pinger/examples/tcp_ping.rs
@@ -1,4 +1,4 @@
-use pinger::{ping, PingOptions};
+use pinger::{ping, PingMode, PingOptions};
 use std::env;
 use std::time::Duration;
 
@@ -16,10 +16,10 @@ fn main() {
         80 // default port
     };
 
-    let opts = PingOptions::new(host, Duration::from_secs(1), None)
-        .with_tcping(true) // enable TCP ping
-        .with_port(port) // set port
-        .with_allow_rst(false); // treat RST as pong
+    let opts = PingOptions::new(host, Duration::from_secs(1), None).with_mode(PingMode::TCP {
+        allow_rst: false, // treat RST as a timeout rather than a pong
+        port: Some(port),
+    });
 
     let rx = ping(opts).expect("Failed to start TCP ping");
 

--- a/pinger/src/lib.rs
+++ b/pinger/src/lib.rs
@@ -43,6 +43,21 @@ mod test;
 
 mod tcp;
 
+/// What a connection refused (RST) means for a TCP ping.
+///
+/// An RST *is* a response: the host answered, it just isn't listening on that port,
+/// and the time it took to arrive is a valid round-trip measurement. That differs
+/// from a real timeout, where nothing came back at all.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RstBehaviour {
+    /// Record the RST as a pong, with the round-trip time it took to arrive.
+    #[default]
+    Pong,
+    /// Treat the RST as a failed ping, the same as no response at all. Useful when
+    /// you care whether a service is actually listening, not whether the host is up.
+    Drop,
+}
+
 /// How to probe the target. The TCP options only apply to TCP pings, so they live
 /// inside that variant rather than sitting unused alongside an ICMP ping.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -50,9 +65,8 @@ pub enum PingMode {
     #[default]
     ICMP,
     TCP {
-        /// Count a connection refused (RST) as a successful pong: the host answered,
-        /// it just isn't listening on this port.
-        allow_rst: bool,
+        /// How to treat a connection refused; see [`RstBehaviour`].
+        rst: RstBehaviour,
         /// Port to connect to; defaults to 80 when unset.
         port: Option<u16>,
     },

--- a/pinger/src/lib.rs
+++ b/pinger/src/lib.rs
@@ -49,8 +49,8 @@ pub struct PingOptions {
     pub interval: Duration,
     pub interface: Option<String>,
     pub raw_arguments: Option<Vec<String>>,
-    pub tcping: bool,     // use TCP instead of ICMP
-    pub allow_rst: bool,  // We can take leverage connection refused as a valid pong in some case
+    pub tcping: bool,      // use TCP instead of ICMP
+    pub allow_rst: bool,   // We can take leverage connection refused as a valid pong in some case
     pub port: Option<u16>, // optional port for TCP ping
 }
 

--- a/pinger/src/lib.rs
+++ b/pinger/src/lib.rs
@@ -43,15 +43,28 @@ mod test;
 
 mod tcp;
 
+/// How to probe the target. The TCP options only apply to TCP pings, so they live
+/// inside that variant rather than sitting unused alongside an ICMP ping.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum PingMode {
+    #[default]
+    ICMP,
+    TCP {
+        /// Count a connection refused (RST) as a successful pong: the host answered,
+        /// it just isn't listening on this port.
+        allow_rst: bool,
+        /// Port to connect to; defaults to 80 when unset.
+        port: Option<u16>,
+    },
+}
+
 #[derive(Debug, Clone)]
 pub struct PingOptions {
     pub target: Target,
     pub interval: Duration,
     pub interface: Option<String>,
     pub raw_arguments: Option<Vec<String>>,
-    pub tcping: bool,      // use TCP instead of ICMP
-    pub allow_rst: bool,   // We can take leverage connection refused as a valid pong in some case
-    pub port: Option<u16>, // optional port for TCP ping
+    pub mode: PingMode,
 }
 
 impl PingOptions {
@@ -73,9 +86,7 @@ impl PingOptions {
             interval,
             interface,
             raw_arguments: None,
-            tcping: false,
-            allow_rst: false,
-            port: Some(80),
+            mode: PingMode::default(),
         }
     }
     pub fn new(target: impl ToString, interval: Duration, interface: Option<String>) -> Self {
@@ -89,18 +100,9 @@ impl PingOptions {
     pub fn new_ipv6(target: impl ToString, interval: Duration, interface: Option<String>) -> Self {
         Self::from_target(Target::new_ipv6(target), interval, interface)
     }
-    /// Enable or disable TCP ping
-    pub fn with_tcping(mut self, tcping: bool) -> Self {
-        self.tcping = tcping;
-        self
-    }
-    /// Allow or disallow treating RST as a valid response
-    pub fn with_allow_rst(mut self, allow: bool) -> Self {
-        self.allow_rst = allow;
-        self
-    }
-    pub fn with_port(mut self, port: u16) -> Self {
-        self.port = Some(port);
+    /// Select how the target is probed; see [`PingMode`].
+    pub fn with_mode(mut self, mode: PingMode) -> Self {
+        self.mode = mode;
         self
     }
 }
@@ -214,8 +216,17 @@ pub enum PingCreationError {
     #[error("Installed ping is not supported: {alternative}")]
     NotSupported { alternative: String },
 
-    #[error("Invalid or unresolvable hostname {0}")]
-    HostnameError(String),
+    #[error("Invalid or unresolvable hostname {hostname}: {err}")]
+    HostnameError {
+        hostname: String,
+        // Not #[from]: SpawnError already provides the From<io::Error> impl, and two
+        // of them on one enum would collide.
+        #[source]
+        err: io::Error,
+    },
+
+    #[error("Internal error: {0}")]
+    InternalError(String),
 }
 
 pub fn get_pinger(options: PingOptions) -> std::result::Result<Arc<dyn Pinger>, PingCreationError> {
@@ -227,7 +238,7 @@ pub fn get_pinger(options: PingOptions) -> std::result::Result<Arc<dyn Pinger>, 
         return Ok(Arc::new(fake::FakePinger::from_options(options)?));
     }
 
-    if options.tcping {
+    if matches!(options.mode, PingMode::TCP { .. }) {
         return Ok(Arc::new(crate::tcp::TcpPinger::from_options(options)?));
     }
 

--- a/pinger/src/tcp.rs
+++ b/pinger/src/tcp.rs
@@ -1,0 +1,74 @@
+use std::net::{TcpStream, ToSocketAddrs};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Instant};
+use std::io::ErrorKind;
+
+
+use crate::{PingOptions, PingResult, Pinger};
+
+pub struct TcpPinger {
+    options: PingOptions,
+}
+
+impl Pinger for TcpPinger {
+    fn from_options(options: PingOptions) -> Result<Self, crate::PingCreationError> {
+        Ok(TcpPinger { options })
+    }
+
+    fn parse_fn(&self) -> fn(String) -> Option<PingResult> {
+        |_| None // TCP doesn't parse lines
+    }
+
+    fn ping_args(&self) -> (&str, Vec<String>) {
+        ("tcp", vec![]) // unused
+    }
+
+    fn start(&self) -> Result<mpsc::Receiver<PingResult>, crate::PingCreationError> {
+        let (tx, rx) = mpsc::channel();
+        let options = self.options.clone();
+
+        thread::spawn(move || {
+            for _ in 0.. {
+                let port = options.port.unwrap_or(80);
+                let socket_str = format!("{}:{}", options.target.to_string(), port);
+                let addr = match socket_str.to_socket_addrs() {
+                    Ok(mut addrs) => match addrs.next() {
+                        Some(a) => a,
+                        None => {
+                            let _ = tx.send(PingResult::Unknown(format!(
+                                "Unable to resolve address"
+                            )));
+                            continue;
+                        }
+                    },
+                    Err(e) => {
+                        let _ = tx.send(PingResult::Unknown(format!("Resolve error: {}", e)));
+                        continue;
+                    }
+                };
+
+                let start = Instant::now();
+                match TcpStream::connect_timeout(&addr, options.interval) {
+                    Ok(_) => {
+                        let _ = tx.send(PingResult::Pong(start.elapsed(), addr.to_string()));
+                    }
+                    Err(e) => {
+                        //println!("DEBUG: error kind for {}: {:?}", addr, e.kind());
+                        let is_rst = matches!(e.kind(), ErrorKind::ConnectionRefused);
+                        if is_rst && options.allow_rst { // treat RST as pong default behavior
+                            let _ = tx.send(PingResult::Pong(start.elapsed(), addr.to_string()));
+                        } else {
+                            let _ = tx.send(PingResult::Timeout(addr.to_string()));
+                        }
+                    }
+                }
+
+                thread::sleep(options.interval);
+            }
+        });
+
+        Ok(rx)
+    }
+}
+

--- a/pinger/src/tcp.rs
+++ b/pinger/src/tcp.rs
@@ -31,14 +31,14 @@ impl Pinger for TcpPinger {
         thread::spawn(move || {
             for _ in 0.. {
                 let port = options.port.unwrap_or(80);
-                let socket_str = format!("{}:{}", options.target.to_string(), port);
+                let socket_str = format!("{}:{}", options.target, port);
                 let addr = match socket_str.to_socket_addrs() {
                     Ok(mut addrs) => match addrs.next() {
                         Some(a) => a,
                         None => {
-                            let _ = tx.send(PingResult::Unknown(format!(
-                                "Unable to resolve address"
-                            )));
+                            let _ = tx.send(PingResult::Unknown(
+                                "Unable to resolve address".to_string()
+                            ));
                             continue;
                         }
                     },

--- a/pinger/src/tcp.rs
+++ b/pinger/src/tcp.rs
@@ -1,18 +1,50 @@
+use std::io;
 use std::io::ErrorKind;
-use std::net::{TcpStream, ToSocketAddrs};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::sync::mpsc;
 use std::thread;
 use std::time::Instant;
 
-use crate::{PingOptions, PingResult, Pinger};
+use crate::{PingCreationError, PingMode, PingOptions, PingResult, Pinger};
 
 pub struct TcpPinger {
     options: PingOptions,
+    allow_rst: bool,
+    port: u16,
+}
+
+impl TcpPinger {
+    /// Resolve the target once, up front, so that a bad hostname surfaces as an error
+    /// from `start` rather than as an endless stream of failed pings.
+    fn resolve(&self) -> Result<SocketAddr, PingCreationError> {
+        let hostname = self.options.target.to_string();
+        let socket_str = format!("{hostname}:{}", self.port);
+        socket_str
+            .to_socket_addrs()
+            .map_err(|err| PingCreationError::HostnameError {
+                hostname: hostname.clone(),
+                err,
+            })?
+            .next()
+            .ok_or_else(|| PingCreationError::HostnameError {
+                hostname,
+                err: io::Error::other("name resolved to no addresses"),
+            })
+    }
 }
 
 impl Pinger for TcpPinger {
-    fn from_options(options: PingOptions) -> Result<Self, crate::PingCreationError> {
-        Ok(TcpPinger { options })
+    fn from_options(options: PingOptions) -> Result<Self, PingCreationError> {
+        match options.mode {
+            PingMode::TCP { allow_rst, port } => Ok(TcpPinger {
+                allow_rst,
+                port: port.unwrap_or(80),
+                options,
+            }),
+            PingMode::ICMP => Err(PingCreationError::InternalError(
+                "ICMP ping options passed to TcpPinger".to_string(),
+            )),
+        }
     }
 
     fn parse_fn(&self) -> fn(String) -> Option<PingResult> {
@@ -23,47 +55,30 @@ impl Pinger for TcpPinger {
         ("tcp", vec![]) // unused
     }
 
-    fn start(&self) -> Result<mpsc::Receiver<PingResult>, crate::PingCreationError> {
+    fn start(&self) -> Result<mpsc::Receiver<PingResult>, PingCreationError> {
         let (tx, rx) = mpsc::channel();
-        let options = self.options.clone();
+        let addr = self.resolve()?;
+        let interval = self.options.interval;
+        let allow_rst = self.allow_rst;
 
         thread::spawn(move || {
-            for _ in 0..=i32::MAX {
-                let port = options.port.unwrap_or(80);
-                let socket_str = format!("{}:{}", options.target, port);
-                let addr = match socket_str.to_socket_addrs() {
-                    Ok(mut addrs) => match addrs.next() {
-                        Some(a) => a,
-                        None => {
-                            let _ = tx
-                                .send(PingResult::Unknown("Unable to resolve address".to_string()));
-                            continue;
-                        }
-                    },
-                    Err(e) => {
-                        let _ = tx.send(PingResult::Unknown(format!("Resolve error: {}", e)));
-                        continue;
+            loop {
+                let start = Instant::now();
+                let sent = match TcpStream::connect_timeout(&addr, interval) {
+                    Ok(_) => tx.send(PingResult::Pong(start.elapsed(), addr.to_string())),
+                    // A RST means the host is up, it just isn't listening on this port
+                    Err(e) if allow_rst && e.kind() == ErrorKind::ConnectionRefused => {
+                        tx.send(PingResult::Pong(start.elapsed(), addr.to_string()))
                     }
+                    Err(_) => tx.send(PingResult::Timeout(addr.to_string())),
                 };
 
-                let start = Instant::now();
-                match TcpStream::connect_timeout(&addr, options.interval) {
-                    Ok(_) => {
-                        let _ = tx.send(PingResult::Pong(start.elapsed(), addr.to_string()));
-                    }
-                    Err(e) => {
-                        //println!("DEBUG: error kind for {}: {:?}", addr, e.kind());
-                        let is_rst = matches!(e.kind(), ErrorKind::ConnectionRefused);
-                        if is_rst && options.allow_rst {
-                            // treat RST as pong default behavior
-                            let _ = tx.send(PingResult::Pong(start.elapsed(), addr.to_string()));
-                        } else {
-                            let _ = tx.send(PingResult::Timeout(addr.to_string()));
-                        }
-                    }
+                // The receiver has hung up, so nothing will read any further pings.
+                if sent.is_err() {
+                    break;
                 }
 
-                thread::sleep(options.interval);
+                thread::sleep(interval);
             }
         });
 

--- a/pinger/src/tcp.rs
+++ b/pinger/src/tcp.rs
@@ -1,9 +1,8 @@
+use std::io::ErrorKind;
 use std::net::{TcpStream, ToSocketAddrs};
 use std::sync::mpsc;
 use std::thread;
-use std::time::{Instant};
-use std::io::ErrorKind;
-
+use std::time::Instant;
 
 use crate::{PingOptions, PingResult, Pinger};
 
@@ -29,16 +28,15 @@ impl Pinger for TcpPinger {
         let options = self.options.clone();
 
         thread::spawn(move || {
-            for _ in 0.. {
+            for _ in 0..=i32::MAX {
                 let port = options.port.unwrap_or(80);
                 let socket_str = format!("{}:{}", options.target, port);
                 let addr = match socket_str.to_socket_addrs() {
                     Ok(mut addrs) => match addrs.next() {
                         Some(a) => a,
                         None => {
-                            let _ = tx.send(PingResult::Unknown(
-                                "Unable to resolve address".to_string()
-                            ));
+                            let _ = tx
+                                .send(PingResult::Unknown("Unable to resolve address".to_string()));
                             continue;
                         }
                     },
@@ -56,7 +54,8 @@ impl Pinger for TcpPinger {
                     Err(e) => {
                         //println!("DEBUG: error kind for {}: {:?}", addr, e.kind());
                         let is_rst = matches!(e.kind(), ErrorKind::ConnectionRefused);
-                        if is_rst && options.allow_rst { // treat RST as pong default behavior
+                        if is_rst && options.allow_rst {
+                            // treat RST as pong default behavior
                             let _ = tx.send(PingResult::Pong(start.elapsed(), addr.to_string()));
                         } else {
                             let _ = tx.send(PingResult::Timeout(addr.to_string()));
@@ -71,4 +70,3 @@ impl Pinger for TcpPinger {
         Ok(rx)
     }
 }
-

--- a/pinger/src/tcp.rs
+++ b/pinger/src/tcp.rs
@@ -5,11 +5,11 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Instant;
 
-use crate::{PingCreationError, PingMode, PingOptions, PingResult, Pinger};
+use crate::{PingCreationError, PingMode, PingOptions, PingResult, Pinger, RstBehaviour};
 
 pub struct TcpPinger {
     options: PingOptions,
-    allow_rst: bool,
+    rst: RstBehaviour,
     port: u16,
 }
 
@@ -36,8 +36,8 @@ impl TcpPinger {
 impl Pinger for TcpPinger {
     fn from_options(options: PingOptions) -> Result<Self, PingCreationError> {
         match options.mode {
-            PingMode::TCP { allow_rst, port } => Ok(TcpPinger {
-                allow_rst,
+            PingMode::TCP { rst, port } => Ok(TcpPinger {
+                rst,
                 port: port.unwrap_or(80),
                 options,
             }),
@@ -59,7 +59,7 @@ impl Pinger for TcpPinger {
         let (tx, rx) = mpsc::channel();
         let addr = self.resolve()?;
         let interval = self.options.interval;
-        let allow_rst = self.allow_rst;
+        let rst = self.rst;
 
         thread::spawn(move || {
             loop {
@@ -67,7 +67,10 @@ impl Pinger for TcpPinger {
                 let sent = match TcpStream::connect_timeout(&addr, interval) {
                     Ok(_) => tx.send(PingResult::Pong(start.elapsed(), addr.to_string())),
                     // A RST means the host is up, it just isn't listening on this port
-                    Err(e) if allow_rst && e.kind() == ErrorKind::ConnectionRefused => {
+                    Err(e)
+                        if rst == RstBehaviour::Pong
+                            && e.kind() == ErrorKind::ConnectionRefused =>
+                    {
                         tx.send(PingResult::Pong(start.elapsed(), addr.to_string()))
                     }
                     Err(_) => tx.send(PingResult::Timeout(addr.to_string())),

--- a/pinger/src/windows.rs
+++ b/pinger/src/windows.rs
@@ -52,7 +52,10 @@ impl Pinger for WindowsPinger {
                         .collect()
                 };
                 if selected_ips.is_empty() {
-                    return Err(PingCreationError::HostnameError(domain.clone()).into());
+                    return Err(PingCreationError::HostnameError {
+                        hostname: domain.clone(),
+                        err: std::io::Error::other("no IPs found"),
+                    });
                 }
                 selected_ips[0].ip()
             }


### PR DESCRIPTION
Hello here is a simple Tcp ping feature

Introduces a new pinger using std:net:TcpStream to measure connection time.

Updated pinger library with new tcp::TcpPinger

Added 3 new PingOptions to the pinger library 
    tcping - to use the tcp pinger - default false
    allow_rst - this is an option to treat connectionRefused as a pong, but the behavior is not always consistent, default false
    port - default 80 - it would be nice to extend the Target to allow ports, but for simplicity just passing a port

On gping the changes are minimal introduced these arguments, to pass the options when creating the pinger.
```
  -t, --tcping
          Use TCP pings instead of ICMP
  -r, --no-rst
          Treat RST as a drop (default is to not consider RST as pong)
  -p, --port <PORT>
          TCP port (only used for TCP pings) [default: 80]
```
Here is how I used it to compare nameserver tcp responses:
 gping -t 127.0.0.53 1.1.1.1 192.168.2.254 8.8.8.8 -p 53 -n 2
 