### PR TITLE
pinger/src/linux.rs: use "ping -6" instead of "ping6"

### DIFF
--- a/pinger/src/linux.rs
+++ b/pinger/src/linux.rs
@@ -64,16 +64,16 @@ impl Pinger for LinuxPinger {
         match self {
             // Alpine doesn't support timeout notifications, so we don't add the -O flag here.
             LinuxPinger::BusyBox(options) => {
-                let cmd = if options.target.is_ipv6() {
-                    "ping6"
-                } else {
-                    "ping"
-                };
+                let cmd = "ping";
 
                 let mut args = vec![
                     options.target.to_string(),
                     format!("-i{:.1}", options.interval.as_millis() as f32 / 1_000_f32),
                 ];
+
+                if options.target.is_ipv6() {
+                    args.push("-6".to_string());
+                }
 
                 if let Some(raw_args) = &options.raw_arguments {
                     args.extend(raw_args.iter().cloned());
@@ -82,11 +82,7 @@ impl Pinger for LinuxPinger {
                 (cmd, args)
             }
             LinuxPinger::IPTools(options) => {
-                let cmd = if options.target.is_ipv6() {
-                    "ping6"
-                } else {
-                    "ping"
-                };
+                let cmd = "ping";
 
                 // The -O flag ensures we "no answer yet" messages from ping
                 // See https://superuser.com/questions/270083/linux-ping-show-time-out
@@ -94,6 +90,11 @@ impl Pinger for LinuxPinger {
                     "-O".to_string(),
                     format!("-i{:.1}", options.interval.as_millis() as f32 / 1_000_f32),
                 ];
+
+                if options.target.is_ipv6() {
+                    args.push("-6".to_string());
+                }
+
                 if let Some(interface) = &options.interface {
                     args.push("-I".into());
                     args.push(interface.clone());


### PR DESCRIPTION
pinger/src/linux.rs: use "ping -6" instead of "ping6"
`ping6` does not exist on my system (`iputils 20250605-1`)

`gping -6` fails otherwise.

```
$ gping -6 example.com
Error: Error spawning ping: No such file or directory (os error 2)

Caused by:
    No such file or directory (os error 2)
```

Note: Probably don't need to modify the BusyBox command.
However, `busybox ping` supports the same `-4/-6` flags:
```
$ busybox ping --help
...
-4,-6           Force IP or IPv6 name resolution
```