### PR TITLE
Add options `--ymin` and `--ymax` for setting vertical scale

### DIFF
--- a/gping.1
+++ b/gping.1
@@ -4,7 +4,7 @@
 .SH NAME
 gping \- Ping, but with a graph.
 .SH SYNOPSIS
-\fBgping\fR [\fB\-\-cmd\fR] [\fB\-n\fR|\fB\-\-watch\-interval\fR] [\fB\-b\fR|\fB\-\-buffer\fR] [\fB\-4 \fR] [\fB\-6 \fR] [\fB\-i\fR|\fB\-\-interface\fR] [\fB\-s\fR|\fB\-\-simple\-graphics\fR] [\fB\-\-vertical\-margin\fR] [\fB\-\-horizontal\-margin\fR] [\fB\-c\fR|\fB\-\-color\fR] [\fB\-\-clear\fR] [\fB\-\-ping\-args\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIHOSTS_OR_COMMANDS\fR] 
+\fBgping\fR [\fB\-\-cmd\fR] [\fB\-n\fR|\fB\-\-watch\-interval\fR] [\fB\-b\fR|\fB\-\-buffer\fR] [\fB\-4 \fR] [\fB\-6 \fR] [\fB\-i\fR|\fB\-\-interface\fR] [\fB\-s\fR|\fB\-\-simple\-graphics\fR] [\fB\-\-vertical\-margin\fR] [\fB\-\-horizontal\-margin\fR] [\fB\-\-ymin\fR] [\fB\-\-ymax\fR] [\fB\-0 \fR] [\fB\-c\fR|\fB\-\-color\fR] [\fB\-\-clear\fR] [\fB\-\-ping\-args\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIHOSTS_OR_COMMANDS\fR] 
 .SH DESCRIPTION
 Ping, but with a graph.
 .SH OPTIONS
@@ -35,6 +35,15 @@ Vertical margin around the graph (top and bottom)
 .TP
 \fB\-\-horizontal\-margin\fR \fI<HORIZONTAL_MARGIN>\fR [default: 0]
 Horizontal margin around the graph (left and right)
+.TP
+\fB\-\-ymin\fR \fI<YMIN>\fR
+Set vertical axis min (ms)
+.TP
+\fB\-\-ymax\fR \fI<YMAX>\fR
+Set vertical axis max (ms)
+.TP
+\fB\-0\fR
+Equivalent to \-\-ymin=0
 .TP
 \fB\-c\fR, \fB\-\-color\fR \fI<color>\fR
 Assign color to a graph entry.

--- a/gping/src/main.rs
+++ b/gping/src/main.rs
@@ -96,6 +96,18 @@ struct Args {
     #[arg(long, default_value = "0")]
     horizontal_margin: u16,
 
+    /// set y-axis minimum
+    #[arg(long, help = "Set vertical axis min (ms)")]
+    ymin: Option<u64>,
+
+    /// set y-axis maximum
+    #[arg(long, help = "Set vertical axis max (ms)")]
+    ymax: Option<u64>,
+
+    /// set y-axis minimum to zero
+    #[arg(short = '0', help = "Equivalent to --ymin=0", conflicts_with = "ymin")]
+    ymin_zero: bool,
+
     #[arg(
         name = "color",
         short = 'c',
@@ -128,15 +140,17 @@ following color names: 'black', 'red', 'green', 'yellow', 'blue', 'magenta',
 struct App {
     data: Vec<PlotData>,
     display_interval: chrono::Duration,
-    started: chrono::DateTime<Local>,
+    started:chrono::DateTime<Local>,
+    yrange: (Option<f64>, Option<f64>)
 }
 
 impl App {
-    fn new(data: Vec<PlotData>, buffer: u64) -> Self {
+    fn new(data: Vec<PlotData>, buffer: u64, yrange: (Option<f64>, Option<f64>)) -> Self {
         App {
             data,
             display_interval: chrono::Duration::from_std(Duration::from_secs(buffer)).unwrap(),
             started: Local::now(),
+            yrange: yrange
         }
     }
 
@@ -149,7 +163,8 @@ impl App {
         // Find the Y axis bounds for our chart.
         // This is trickier than the x-axis. We iterate through all our PlotData structs
         // and find the min/max of all the values. Then we add a 10% buffer to them.
-        let (min, max) = match self
+        let (ymin, ymax) = self.yrange;
+        let (mut min, mut max) = match self
             .data
             .iter()
             .flat_map(|b| b.data.as_slice())
@@ -158,14 +173,27 @@ impl App {
             .minmax()
         {
             MinMaxResult::NoElements => (f64::INFINITY, 0_f64),
-            MinMaxResult::OneElement(elm) => (elm, elm),
-            MinMaxResult::MinMax(min, max) => (min, max),
+            MinMaxResult::OneElement(elm) => (
+                ymin.unwrap_or(elm),
+                elm
+            ),
+            MinMaxResult::MinMax(min, max) => (
+                ymin.unwrap_or(min),
+                ymax.unwrap_or(max),
+            )
         };
 
+        // Reject negative bounds
+        // Show at least 1 ms of y-axis
+        if ymin != None {
+            min = min.clamp(0.0, f64::INFINITY);
+            max = max.clamp(min + 1000.0, f64::INFINITY);
+        }
+
         // Add a 10% buffer to the top and bottom
-        let max_10_percent = (max * 10_f64) / 100_f64;
-        let min_10_percent = (min * 10_f64) / 100_f64;
-        [min - min_10_percent, max + max_10_percent]
+        let pos_margin = (max * 10_f64) / 100_f64;
+        let neg_margin = (min * 10_f64) / 100_f64;
+        [min - neg_margin, max + pos_margin]
     }
 
     fn x_axis_bounds(&self) -> [f64; 2] {
@@ -353,6 +381,15 @@ fn get_host_ipaddr(host: &str, force_ipv4: bool, force_ipv6: bool) -> Result<Str
     Ok(ipaddr?.to_string())
 }
 
+// Convert milliseconds Option<u64>
+// to microseconds Option<f64>.
+fn ms_to_us_option(ms: Option<u64>) -> Option<f64> {
+    match ms {
+        None => None,
+        Some(x) => Some(1000.0 * (x as f64))
+    }
+}
+
 fn generate_man_page(path: &Path) -> anyhow::Result<()> {
     let man = clap_mangen::Man::new(Args::command().version(None).long_version(None));
     let mut buffer: Vec<u8> = Default::default();
@@ -371,6 +408,11 @@ fn main() -> Result<()> {
     if args.hosts_or_commands.is_empty() {
         return Err(anyhow!("At least one host or command must be given (i.e gping google.com). Use --help for a full list of arguments."));
     }
+
+    let yrange = (
+        ms_to_us_option(if args.ymin_zero {Some(0)} else {args.ymin}),
+        ms_to_us_option(args.ymax)
+    );
 
     let mut data = vec![];
 
@@ -457,7 +499,7 @@ fn main() -> Result<()> {
         key_tx.clone(),
     ));
 
-    let mut app = App::new(data, args.buffer);
+    let mut app = App::new(data, args.buffer, yrange);
     enable_raw_mode()?;
     let stdout = io::stdout();
     let mut backend = CrosstermBackend::new(BufWriter::with_capacity(1024 * 1024 * 4, stdout));

--- a/gping/src/main.rs
+++ b/gping/src/main.rs
@@ -130,8 +130,8 @@ following color names: 'black', 'red', 'green', 'yellow', 'blue', 'magenta',
 struct App {
     data: Vec<PlotData>,
     display_interval: chrono::Duration,
-    started:chrono::DateTime<Local>,
-    yrange: (Option<f64>, Option<f64>)
+    started: chrono::DateTime<Local>,
+    yrange: (Option<f64>, Option<f64>),
 }
 
 impl App {
@@ -140,7 +140,7 @@ impl App {
             data,
             display_interval: chrono::Duration::from_std(Duration::from_secs(buffer)).unwrap(),
             started: Local::now(),
-            yrange: yrange
+            yrange,
         }
     }
 
@@ -163,19 +163,13 @@ impl App {
             .minmax()
         {
             MinMaxResult::NoElements => (f64::INFINITY, 0_f64),
-            MinMaxResult::OneElement(elm) => (
-                ymin.unwrap_or(elm),
-                elm
-            ),
-            MinMaxResult::MinMax(min, max) => (
-                ymin.unwrap_or(min),
-                ymax.unwrap_or(max),
-            )
+            MinMaxResult::OneElement(elm) => (ymin.unwrap_or(elm), elm),
+            MinMaxResult::MinMax(min, max) => (ymin.unwrap_or(min), ymax.unwrap_or(max)),
         };
 
         // Reject negative bounds
         // Show at least 1 ms of y-axis
-        if ymin != None {
+        if ymin.is_some() {
             min = min.clamp(0.0, f64::INFINITY);
             max = max.clamp(min + 1000.0, f64::INFINITY);
         }
@@ -376,10 +370,7 @@ fn get_host_ipaddr(host: &str, force_ipv4: bool, force_ipv6: bool) -> Result<Str
 // Convert milliseconds Option<u64>
 // to microseconds Option<f64>.
 fn ms_to_us_option(ms: Option<u64>) -> Option<f64> {
-    match ms {
-        None => None,
-        Some(x) => Some(1000.0 * (x as f64))
-    }
+    ms.map(|x| 1000.0 * (x as f64))
 }
 
 fn generate_man_page(path: &Path) -> anyhow::Result<()> {
@@ -402,8 +393,8 @@ fn main() -> Result<()> {
     }
 
     let yrange = (
-        ms_to_us_option(if args.ymin_zero {Some(0)} else {args.ymin}),
-        ms_to_us_option(args.ymax)
+        ms_to_us_option(if args.ymin_zero { Some(0) } else { args.ymin }),
+        ms_to_us_option(args.ymax),
     );
 
     let mut data = vec![];

--- a/gping/src/main.rs
+++ b/gping/src/main.rs
@@ -86,6 +86,18 @@ struct Args {
     #[arg(long, default_value = "0")]
     horizontal_margin: u16,
 
+    /// set y-axis minimum
+    #[arg(long, help = "Set vertical axis min (ms)")]
+    ymin: Option<u64>,
+
+    /// set y-axis maximum
+    #[arg(long, help = "Set vertical axis max (ms)")]
+    ymax: Option<u64>,
+
+    /// set y-axis minimum to zero
+    #[arg(short = '0', help = "Equivalent to --ymin=0", conflicts_with = "ymin")]
+    ymin_zero: bool,
+
     #[arg(
         name = "color",
         short = 'c',
@@ -118,15 +130,17 @@ following color names: 'black', 'red', 'green', 'yellow', 'blue', 'magenta',
 struct App {
     data: Vec<PlotData>,
     display_interval: chrono::Duration,
-    started: chrono::DateTime<Local>,
+    started:chrono::DateTime<Local>,
+    yrange: (Option<f64>, Option<f64>)
 }
 
 impl App {
-    fn new(data: Vec<PlotData>, buffer: u64) -> Self {
+    fn new(data: Vec<PlotData>, buffer: u64, yrange: (Option<f64>, Option<f64>)) -> Self {
         App {
             data,
             display_interval: chrono::Duration::from_std(Duration::from_secs(buffer)).unwrap(),
             started: Local::now(),
+            yrange: yrange
         }
     }
 
@@ -139,7 +153,8 @@ impl App {
         // Find the Y axis bounds for our chart.
         // This is trickier than the x-axis. We iterate through all our PlotData structs
         // and find the min/max of all the values. Then we add a 10% buffer to them.
-        let (min, max) = match self
+        let (ymin, ymax) = self.yrange;
+        let (mut min, mut max) = match self
             .data
             .iter()
             .flat_map(|b| b.data.as_slice())
@@ -148,14 +163,27 @@ impl App {
             .minmax()
         {
             MinMaxResult::NoElements => (f64::INFINITY, 0_f64),
-            MinMaxResult::OneElement(elm) => (elm, elm),
-            MinMaxResult::MinMax(min, max) => (min, max),
+            MinMaxResult::OneElement(elm) => (
+                ymin.unwrap_or(elm),
+                elm
+            ),
+            MinMaxResult::MinMax(min, max) => (
+                ymin.unwrap_or(min),
+                ymax.unwrap_or(max),
+            )
         };
 
+        // Reject negative bounds
+        // Show at least 1 ms of y-axis
+        if ymin != None {
+            min = min.clamp(0.0, f64::INFINITY);
+            max = max.clamp(min + 1000.0, f64::INFINITY);
+        }
+
         // Add a 10% buffer to the top and bottom
-        let max_10_percent = (max * 10_f64) / 100_f64;
-        let min_10_percent = (min * 10_f64) / 100_f64;
-        [min - min_10_percent, max + max_10_percent]
+        let pos_margin = (max * 10_f64) / 100_f64;
+        let neg_margin = (min * 10_f64) / 100_f64;
+        [min - neg_margin, max + pos_margin]
     }
 
     fn x_axis_bounds(&self) -> [f64; 2] {
@@ -345,6 +373,15 @@ fn get_host_ipaddr(host: &str, force_ipv4: bool, force_ipv6: bool) -> Result<Str
     Ok(ipaddr?.to_string())
 }
 
+// Convert milliseconds Option<u64>
+// to microseconds Option<f64>.
+fn ms_to_us_option(ms: Option<u64>) -> Option<f64> {
+    match ms {
+        None => None,
+        Some(x) => Some(1000.0 * (x as f64))
+    }
+}
+
 fn generate_man_page(path: &Path) -> anyhow::Result<()> {
     let man = clap_mangen::Man::new(Args::command().version(None).long_version(None));
     let mut buffer: Vec<u8> = Default::default();
@@ -363,6 +400,11 @@ fn main() -> Result<()> {
     if args.hosts_or_commands.is_empty() {
         return Err(anyhow!("At least one host or command must be given (i.e gping google.com). Use --help for a full list of arguments."));
     }
+
+    let yrange = (
+        ms_to_us_option(if args.ymin_zero {Some(0)} else {args.ymin}),
+        ms_to_us_option(args.ymax)
+    );
 
     let mut data = vec![];
 
@@ -450,7 +492,7 @@ fn main() -> Result<()> {
         key_tx.clone(),
     ));
 
-    let mut app = App::new(data, args.buffer);
+    let mut app = App::new(data, args.buffer, yrange);
     enable_raw_mode()?;
     let stdout = io::stdout();
     let mut backend = CrosstermBackend::new(BufWriter::with_capacity(1024 * 1024 * 4, stdout));


### PR DESCRIPTION
Fixes #406.

I have been running a similar patch for a few months now. Having the y-axis start at zero is fairly important :) [^1] I have been using the `-0` flag pretty much all of the time.

Finally got around to cleaning up my code. I'm not super familiar with Rust, so let me know it there are any changes needed to make the code more idiomatic.

---

- Add options `--ymin` and `--ymax` for setting vertical scale
- Option `-0` is an alias for `--ymin=0`
- Ensures at least 1 ms of y-axis when using `--ymin=0`
  - (Relevant for sub-ms hosts, e.g. `gping -0 127.0.0.1`)

```
# gping --help
.
  --ymin <YMIN> Set vertical axis min (ms)
  --ymax <YMAX> Set vertical axis max (ms)
  -0            Equivalent to --ymin=0
.
```

---

Comparison (before=bottom, after=top) `gping -b10 --ymin 0 --ymax 500 3.80.0.0`
<img width="1005" alt="comparison" src="https://github.com/user-attachments/assets/5c260900-3f4d-4468-9c47-6a899d4f7b41" />

[^1]: https://xkcd.com/2023/
