### PR TITLE
fix, linux: don't hard code expected bytes

### DIFF
--- a/pinger/src/linux.rs
+++ b/pinger/src/linux.rs
@@ -51,7 +51,7 @@ impl Pinger for LinuxPinger {
         |line| {
             #[cfg(test)]
             eprintln!("Got line {line}");
-            if line.starts_with("64 bytes from") {
+            if line.contains("bytes from") {
                 return extract_regex(&UBUNTU_RE, line);
             } else if line.starts_with("no answer yet") {
                 return Some(PingResult::Timeout(line));


### PR DESCRIPTION
Hard coding the expected returned bytes (64) prevents the user from specifying the size argument via --ping_args, which is useful for troubleshooting. Without this change, no ping response is detected by gping when a non-default size argument is specified. 