### PR TITLE
Compute jitter in chronological order, not sorted order

### DIFF
--- a/gping/src/plot_data.rs
+++ b/gping/src/plot_data.rs
@@ -51,6 +51,15 @@ impl PlotData {
 
     pub fn header_stats(&self) -> Vec<Paragraph<'_>> {
         let ping_header = Paragraph::new(self.display.clone()).style(self.style);
+        // Chronologically-ordered (i.e. not sorted) latencies, used for the jitter
+        // calculation which needs to compare consecutive samples in the order they
+        // actually occurred.
+        let chronological: Vec<f64> = self
+            .data
+            .iter()
+            .filter(|(_, x)| !x.is_nan())
+            .map(|(_, v)| *v)
+            .collect();
         let items: Vec<&f64> = self
             .data
             .iter()
@@ -65,12 +74,7 @@ impl PlotData {
         let min = **items.first().unwrap();
         let max = **items.last().unwrap();
         let avg = items.iter().copied().sum::<f64>() / items.len() as f64;
-        let jtr = items
-            .iter()
-            .zip(items.iter().skip(1))
-            .map(|(&prev, &curr)| (curr - prev).abs())
-            .sum::<f64>()
-            / (items.len() - 1) as f64;
+        let jtr = jitter(&chronological);
 
         let percentile_position = 0.95 * items.len() as f32;
         let rounded_position = percentile_position.round() as usize;
@@ -100,6 +104,22 @@ impl PlotData {
     }
 }
 
+/// Average absolute difference between consecutive values, taken in the order
+/// they are given (i.e. the caller is responsible for passing them in
+/// chronological order, not sorted). With fewer than two values there is no
+/// consecutive pair to compare, so jitter is reported as 0.
+fn jitter(values: &[f64]) -> f64 {
+    if values.len() < 2 {
+        return 0.0;
+    }
+    values
+        .iter()
+        .zip(values.iter().skip(1))
+        .map(|(prev, curr)| (curr - prev).abs())
+        .sum::<f64>()
+        / (values.len() - 1) as f64
+}
+
 impl<'a> From<&'a PlotData> for Dataset<'a> {
     fn from(plot: &'a PlotData) -> Self {
         let slice = plot.data.as_slice();
@@ -112,5 +132,35 @@ impl<'a> From<&'a PlotData> for Dataset<'a> {
             .style(plot.style)
             .graph_type(GraphType::Line)
             .data(slice)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_jitter_uses_chronological_order() {
+        // Oscillating latencies: sorted-order "jitter" would telescope down to
+        // (max - min) / (n - 1) = (90 - 10) / 5 = 16, which is really a range
+        // statistic, not jitter. In chronological order every consecutive pair
+        // differs by 80, so the real jitter should be 80.
+        let values = vec![10.0, 90.0, 10.0, 90.0, 10.0, 90.0];
+
+        let sorted_order_value = (90.0 - 10.0) / (values.len() - 1) as f64;
+        let result = jitter(&values);
+
+        assert_eq!(result, 80.0);
+        assert_ne!(result, sorted_order_value);
+    }
+
+    #[test]
+    fn test_jitter_single_sample_is_zero() {
+        assert_eq!(jitter(&[42.0]), 0.0);
+    }
+
+    #[test]
+    fn test_jitter_empty_is_zero() {
+        assert_eq!(jitter(&[]), 0.0);
     }
 }


### PR DESCRIPTION
## What's broken

The `jtr` figure in the header is not jitter. It is always `(max - min) / (n - 1)`, a range statistic, so it cannot tell a stable connection from an oscillating one whenever the extremes are the same.

## Why

`header_stats` sorts the latencies into `items`, then takes the mean absolute difference between consecutive elements of that sorted list. On a sorted list every difference is non-negative, so the sum telescopes to exactly `max - min`.

With the sequence `[10, 90, 10, 90, 10, 90]`, which is about as jittery as a connection gets:

```
current  jtr (sorted order)       = 16
real jitter (chronological order) = 80
```

## The fix

Compute the consecutive differences over the latencies in the order they arrived, before the sort. `min`, `max`, `avg` and `p95` still come from the sorted list, unchanged.

`self.data` is chronological by construction: `update` only pushes new samples and drains a prefix of expired ones, so nothing reorders it.

Also made the single-sample case explicit. It used to divide by zero, produce `NaN`, and rely on `NaN as u64` saturating to 0 in the cast. It now returns 0 directly, so the display is the same without depending on that cast.

## Verification

Three tests in `plot_data.rs`, which had no test module before. The main one asserts the oscillating sequence gives 80 and specifically not the sorted-order 16; it fails against the old code with `left: 16.0, right: 80.0`. `cargo test` passes and `cargo clippy --all-targets` adds no new warnings.

Kept the diff to the jitter calculation so it does not collide with #580, which touches the buffer drain in the same file.
